### PR TITLE
Add email verification flow. 

### DIFF
--- a/safetrace-app/Common UI/Button.swift
+++ b/safetrace-app/Common UI/Button.swift
@@ -5,6 +5,11 @@ enum ButtonStyle {
     case secondary
 }
 
+enum ButtonSize {
+    case large
+    case small
+}
+
 class Button: UIButton {
     lazy var gradientLayer: CAGradientLayer = {
         let layer = CAGradientLayer()
@@ -31,12 +36,18 @@ class Button: UIButton {
         }
     }
 
-    init(style: ButtonStyle) {
+    init(style: ButtonStyle, size: ButtonSize = .large) {
         self.style = style
         super.init(frame: .zero)
 
-        heightAnchor.constraint(equalToConstant: 48).isActive = true
-        layer.cornerRadius = 24
+        switch size {
+        case .large:
+            heightAnchor.constraint(equalToConstant: 48).isActive = true
+            layer.cornerRadius = 24
+        case .small:
+            heightAnchor.constraint(equalToConstant: 32).isActive = true
+            layer.cornerRadius = 16
+        }
         layer.masksToBounds = true
 
         titleLabel?.font = .titleH3

--- a/safetrace-app/Constants.swift
+++ b/safetrace-app/Constants.swift
@@ -1,4 +1,5 @@
 struct Constants {
     static let termsOfUseUrl = "https://citizen.com/tracing/terms"
     static let privacyPolicyUrl = "https://citizen.com/tracing/privacy"
+    static let contactCitizenUrl = "https://support.citizen.com/hc/en-us/requests/new"
 }

--- a/safetrace-app/Home/Onboarding/Auth Step/EmailVerificationViewController.swift
+++ b/safetrace-app/Home/Onboarding/Auth Step/EmailVerificationViewController.swift
@@ -1,0 +1,184 @@
+import ReactiveCocoa
+import ReactiveSwift
+import SafeTrace
+import UIKit
+
+class EmailVerificationViewController: OnboardingViewController {
+
+    private let verificationContext: LoginResponseContext.EmailVerificationData
+    private let codeTextField = TextField()
+    private let resendButton = Button(style: .secondary, size: .small)
+    private let needHelpButton = UIButton()
+
+    init(
+        environment: Environment,
+        verificationContext: LoginResponseContext.EmailVerificationData,
+        onboardingStep: OnboardingStep
+    ) {
+        self.verificationContext = verificationContext
+        super.init(environment: environment, onboardingStep: onboardingStep)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        // MARK: - UI Components
+
+        let titleLabel = UILabel()
+        titleLabel.font = .titleH2
+        titleLabel.textColor = .stBlack
+        titleLabel.text = NSLocalizedString("Check your email", comment: "Email verification title")
+        titleLabel.textAlignment = .left
+
+        let subtitleLabel = UILabel()
+        subtitleLabel.font = .titleH2
+        subtitleLabel.textColor = .stGrey55
+        subtitleLabel.numberOfLines = 0
+        let subtitleTemplate = NSLocalizedString(
+            "To log in, you need to verify your account. Enter the code in the email we sent to %@.",
+            comment: "Email verification subtitle"
+        )
+        subtitleLabel.text = String(format: subtitleTemplate, verificationContext.email)
+        subtitleLabel.textAlignment = .left
+
+        let enterCodeLabel = UILabel()
+        enterCodeLabel.font = .titleH6
+        enterCodeLabel.textColor = .stGrey40
+        enterCodeLabel.text = NSLocalizedString("Enter Code", comment: "Email verification code label")
+            .uppercased(with: .current)
+        enterCodeLabel.textAlignment = .left
+
+        codeTextField.keyboardType = .numberPad
+        codeTextField.delegate = self
+
+        resendButton.setTitle(
+            NSLocalizedString("Resend Email", comment: "Email verification resend email button title")
+                .uppercased(with: .current),
+            for: .normal
+        )
+        resendButton.titleLabel?.font = .smallSemibold
+        resendButton.setTitleColor(.stPurple, for: .normal)
+        resendButton.setTitleColor(UIColor.stPurple.withAlphaComponent(0.8), for: .highlighted)
+        resendButton.addTarget(self, action: #selector(didTapResendButton), for: .touchUpInside)
+        resendButton.contentEdgeInsets = .init(top: 0, left: 12, bottom: 0, right: 12)
+
+        needHelpButton.setTitle(
+            NSLocalizedString("Need help? Contact Citizen", comment: "Email verification resend button title"),
+            for: .normal
+        )
+        needHelpButton.titleLabel?.font = .smallSemibold
+        needHelpButton.setTitleColor(.stPurple, for: .normal)
+        needHelpButton.setTitleColor(UIColor.stPurple.withAlphaComponent(0.8), for: .highlighted)
+        needHelpButton.addTarget(self, action: #selector(didTapNeedHelpButton), for: .touchUpInside)
+
+        let stackView = UIStackView(arrangedSubviews: [
+            titleLabel,
+            subtitleLabel,
+            enterCodeLabel,
+            codeTextField,
+            resendButton,
+            needHelpButton
+        ])
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .fill
+
+        view.addSubview(stackView)
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        codeTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 18),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 28),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -28),
+            titleLabel.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            subtitleLabel.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            enterCodeLabel.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            codeTextField.widthAnchor.constraint(equalTo: stackView.widthAnchor)
+        ])
+
+        stackView.setCustomSpacing(3, after: titleLabel)
+        stackView.setCustomSpacing(30, after: subtitleLabel)
+        stackView.setCustomSpacing(8, after: enterCodeLabel)
+        stackView.setCustomSpacing(48, after: codeTextField)
+        stackView.setCustomSpacing(25, after: resendButton)
+    }
+
+    @objc private func didTapResendButton() {
+        self.resendButton.setTitle(
+            NSLocalizedString("Sending...", comment: "Email verification sending email button title")
+                .uppercased(with: .current),
+            for: .normal
+        )
+
+        environment.safeTrace.session.resendEmailAuthCode(
+            phone: verificationContext.phoneNumber,
+            deviceID: verificationContext.deviceID
+        ) { [weak self] result in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.resendButton.isEnabled = false
+                    self.resendButton.setTitle(
+                        NSLocalizedString("Sent", comment: "Email verification successfully re-sent email button title")
+                            .uppercased(with: .current),
+                        for: .normal
+                    )
+                case .failure:
+                    self.resendButton.isEnabled = true
+                    self.resendButton.setTitle(
+                        NSLocalizedString("Resend Email", comment: "Email verification resend email button title")
+                            .uppercased(with: .current),
+                        for: .normal
+                    )
+                }
+            }
+        }
+    }
+
+    @objc private func didTapNeedHelpButton() {
+        let webViewController = WebViewController()
+        webViewController.loadUrl(URL(string: Constants.contactCitizenUrl)!)
+        present(webViewController, animated: true)
+    }
+
+    private func verifyCode(_ code: String) {
+        environment.safeTrace.session.authenticateWithEmailCode(code, phone: verificationContext.phoneNumber) { [weak self] result in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.onboardingStep.stepCompleted()
+                case .failure:
+                    self.codeTextField.setState(.error)
+                }
+            }
+        }
+    }
+}
+
+extension EmailVerificationViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let currentText = textField.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+
+        let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+
+        if updatedText.count == 4 {
+            verifyCode(updatedText)
+        }
+
+        return updatedText.count <= 4
+    }
+}

--- a/safetrace-sdk-tests/mock/Mock.generated.swift
+++ b/safetrace-sdk-tests/mock/Mock.generated.swift
@@ -627,10 +627,22 @@ open class NetworkProtocolMock: NetworkProtocol, Mock {
 		perform?(`phone`, `completion`)
     }
 
-    open func authenticateWithCode(_ token: String, phone: String, completion: @escaping (Result<AuthData, Error>) -> Void) {
-        addInvocation(.m_authenticateWithCode__tokenphone_phonecompletion_completion(Parameter<String>.value(`token`), Parameter<String>.value(`phone`), Parameter<(Result<AuthData, Error>) -> Void>.value(`completion`)))
-		let perform = methodPerformValue(.m_authenticateWithCode__tokenphone_phonecompletion_completion(Parameter<String>.value(`token`), Parameter<String>.value(`phone`), Parameter<(Result<AuthData, Error>) -> Void>.value(`completion`))) as? (String, String, @escaping (Result<AuthData, Error>) -> Void) -> Void
-		perform?(`token`, `phone`, `completion`)
+    open func authenticateWithCode(_ token: String, phone: String, deviceID: String?, completion: @escaping (Result<AuthData, Error>) -> Void) {
+        addInvocation(.m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>.value(`token`), Parameter<String>.value(`phone`), Parameter<String?>.value(`deviceID`), Parameter<(Result<AuthData, Error>) -> Void>.value(`completion`)))
+		let perform = methodPerformValue(.m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>.value(`token`), Parameter<String>.value(`phone`), Parameter<String?>.value(`deviceID`), Parameter<(Result<AuthData, Error>) -> Void>.value(`completion`))) as? (String, String, String?, @escaping (Result<AuthData, Error>) -> Void) -> Void
+		perform?(`token`, `phone`, `deviceID`, `completion`)
+    }
+
+    open func authenticateWithEmailCode(_ code: String, phone: String, completion: @escaping (Result<AuthData, Error>) -> Void) {
+        addInvocation(.m_authenticateWithEmailCode__codephone_phonecompletion_completion(Parameter<String>.value(`code`), Parameter<String>.value(`phone`), Parameter<(Result<AuthData, Error>) -> Void>.value(`completion`)))
+		let perform = methodPerformValue(.m_authenticateWithEmailCode__codephone_phonecompletion_completion(Parameter<String>.value(`code`), Parameter<String>.value(`phone`), Parameter<(Result<AuthData, Error>) -> Void>.value(`completion`))) as? (String, String, @escaping (Result<AuthData, Error>) -> Void) -> Void
+		perform?(`code`, `phone`, `completion`)
+    }
+
+    open func resendEmailAuthCode(phone: String, deviceID: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        addInvocation(.m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>.value(`phone`), Parameter<String?>.value(`deviceID`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`)))
+		let perform = methodPerformValue(.m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>.value(`phone`), Parameter<String?>.value(`deviceID`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`))) as? (String, String?, @escaping (Result<Void, Error>) -> Void) -> Void
+		perform?(`phone`, `deviceID`, `completion`)
     }
 
     open func setTracingEnabled(_ enabled: Bool, userID: String, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -666,7 +678,9 @@ open class NetworkProtocolMock: NetworkProtocol, Mock {
 
     fileprivate enum MethodType {
         case m_requestAuthCode__phone_phonecompletion_completion(Parameter<String>, Parameter<(Result<Void, Error>) -> Void>)
-        case m_authenticateWithCode__tokenphone_phonecompletion_completion(Parameter<String>, Parameter<String>, Parameter<(Result<AuthData, Error>) -> Void>)
+        case m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>, Parameter<String>, Parameter<String?>, Parameter<(Result<AuthData, Error>) -> Void>)
+        case m_authenticateWithEmailCode__codephone_phonecompletion_completion(Parameter<String>, Parameter<String>, Parameter<(Result<AuthData, Error>) -> Void>)
+        case m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>, Parameter<String?>, Parameter<(Result<Void, Error>) -> Void>)
         case m_setTracingEnabled__enableduserID_userIDcompletion_completion(Parameter<Bool>, Parameter<String>, Parameter<(Result<Void, Error>) -> Void>)
         case m_syncPushToken__tokencompletion_completion(Parameter<Data>, Parameter<(Result<Void, Error>) -> Void>)
         case m_sendHealthCheck__userID_userIDbluetoothEnabled_bluetoothEnablednotificationsEnabled_notificationsEnabledcompletion_completion(Parameter<String>, Parameter<Bool>, Parameter<Bool>, Parameter<(Result<Void, Error>) -> Void>)
@@ -679,9 +693,20 @@ open class NetworkProtocolMock: NetworkProtocol, Mock {
                 guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
                 guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
                 return true 
-            case (.m_authenticateWithCode__tokenphone_phonecompletion_completion(let lhsToken, let lhsPhone, let lhsCompletion), .m_authenticateWithCode__tokenphone_phonecompletion_completion(let rhsToken, let rhsPhone, let rhsCompletion)):
+            case (.m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(let lhsToken, let lhsPhone, let lhsDeviceid, let lhsCompletion), .m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(let rhsToken, let rhsPhone, let rhsDeviceid, let rhsCompletion)):
                 guard Parameter.compare(lhs: lhsToken, rhs: rhsToken, with: matcher) else { return false } 
                 guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsDeviceid, rhs: rhsDeviceid, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
+                return true 
+            case (.m_authenticateWithEmailCode__codephone_phonecompletion_completion(let lhsCode, let lhsPhone, let lhsCompletion), .m_authenticateWithEmailCode__codephone_phonecompletion_completion(let rhsCode, let rhsPhone, let rhsCompletion)):
+                guard Parameter.compare(lhs: lhsCode, rhs: rhsCode, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
+                return true 
+            case (.m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(let lhsPhone, let lhsDeviceid, let lhsCompletion), .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(let rhsPhone, let rhsDeviceid, let rhsCompletion)):
+                guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsDeviceid, rhs: rhsDeviceid, with: matcher) else { return false } 
                 guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
                 return true 
             case (.m_setTracingEnabled__enableduserID_userIDcompletion_completion(let lhsEnabled, let lhsUserid, let lhsCompletion), .m_setTracingEnabled__enableduserID_userIDcompletion_completion(let rhsEnabled, let rhsUserid, let rhsCompletion)):
@@ -715,7 +740,9 @@ open class NetworkProtocolMock: NetworkProtocol, Mock {
         func intValue() -> Int {
             switch self {
             case let .m_requestAuthCode__phone_phonecompletion_completion(p0, p1): return p0.intValue + p1.intValue
-            case let .m_authenticateWithCode__tokenphone_phonecompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
+            case let .m_authenticateWithEmailCode__codephone_phonecompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_setTracingEnabled__enableduserID_userIDcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_syncPushToken__tokencompletion_completion(p0, p1): return p0.intValue + p1.intValue
             case let .m_sendHealthCheck__userID_userIDbluetoothEnabled_bluetoothEnablednotificationsEnabled_notificationsEnabledcompletion_completion(p0, p1, p2, p3): return p0.intValue + p1.intValue + p2.intValue + p3.intValue
@@ -740,7 +767,9 @@ open class NetworkProtocolMock: NetworkProtocol, Mock {
         fileprivate var method: MethodType
 
         public static func requestAuthCode(phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_requestAuthCode__phone_phonecompletion_completion(`phone`, `completion`))}
-        public static func authenticateWithCode(_ token: Parameter<String>, phone: Parameter<String>, completion: Parameter<(Result<AuthData, Error>) -> Void>) -> Verify { return Verify(method: .m_authenticateWithCode__tokenphone_phonecompletion_completion(`token`, `phone`, `completion`))}
+        public static func authenticateWithCode(_ token: Parameter<String>, phone: Parameter<String>, deviceID: Parameter<String?>, completion: Parameter<(Result<AuthData, Error>) -> Void>) -> Verify { return Verify(method: .m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(`token`, `phone`, `deviceID`, `completion`))}
+        public static func authenticateWithEmailCode(_ code: Parameter<String>, phone: Parameter<String>, completion: Parameter<(Result<AuthData, Error>) -> Void>) -> Verify { return Verify(method: .m_authenticateWithEmailCode__codephone_phonecompletion_completion(`code`, `phone`, `completion`))}
+        public static func resendEmailAuthCode(phone: Parameter<String>, deviceID: Parameter<String?>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(`phone`, `deviceID`, `completion`))}
         public static func setTracingEnabled(_ enabled: Parameter<Bool>, userID: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_setTracingEnabled__enableduserID_userIDcompletion_completion(`enabled`, `userID`, `completion`))}
         public static func syncPushToken(_ token: Parameter<Data>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_syncPushToken__tokencompletion_completion(`token`, `completion`))}
         public static func sendHealthCheck(userID: Parameter<String>, bluetoothEnabled: Parameter<Bool>, notificationsEnabled: Parameter<Bool>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_sendHealthCheck__userID_userIDbluetoothEnabled_bluetoothEnablednotificationsEnabled_notificationsEnabledcompletion_completion(`userID`, `bluetoothEnabled`, `notificationsEnabled`, `completion`))}
@@ -755,8 +784,14 @@ open class NetworkProtocolMock: NetworkProtocol, Mock {
         public static func requestAuthCode(phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (String, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
             return Perform(method: .m_requestAuthCode__phone_phonecompletion_completion(`phone`, `completion`), performs: perform)
         }
-        public static func authenticateWithCode(_ token: Parameter<String>, phone: Parameter<String>, completion: Parameter<(Result<AuthData, Error>) -> Void>, perform: @escaping (String, String, @escaping (Result<AuthData, Error>) -> Void) -> Void) -> Perform {
-            return Perform(method: .m_authenticateWithCode__tokenphone_phonecompletion_completion(`token`, `phone`, `completion`), performs: perform)
+        public static func authenticateWithCode(_ token: Parameter<String>, phone: Parameter<String>, deviceID: Parameter<String?>, completion: Parameter<(Result<AuthData, Error>) -> Void>, perform: @escaping (String, String, String?, @escaping (Result<AuthData, Error>) -> Void) -> Void) -> Perform {
+            return Perform(method: .m_authenticateWithCode__tokenphone_phonedeviceID_deviceIDcompletion_completion(`token`, `phone`, `deviceID`, `completion`), performs: perform)
+        }
+        public static func authenticateWithEmailCode(_ code: Parameter<String>, phone: Parameter<String>, completion: Parameter<(Result<AuthData, Error>) -> Void>, perform: @escaping (String, String, @escaping (Result<AuthData, Error>) -> Void) -> Void) -> Perform {
+            return Perform(method: .m_authenticateWithEmailCode__codephone_phonecompletion_completion(`code`, `phone`, `completion`), performs: perform)
+        }
+        public static func resendEmailAuthCode(phone: Parameter<String>, deviceID: Parameter<String?>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (String, String?, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
+            return Perform(method: .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(`phone`, `deviceID`, `completion`), performs: perform)
         }
         public static func setTracingEnabled(_ enabled: Parameter<Bool>, userID: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (Bool, String, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
             return Perform(method: .m_setTracingEnabled__enableduserID_userIDcompletion_completion(`enabled`, `userID`, `completion`), performs: perform)
@@ -1492,9 +1527,9 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
 		perform?()
     }
 
-    open func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<Void, Error>) -> Void) {
-        addInvocation(.m_authenticateWithCode__phonephone_completioncompletion(Parameter<String>.value(`phone`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`)))
-		let perform = methodPerformValue(.m_authenticateWithCode__phonephone_completioncompletion(Parameter<String>.value(`phone`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`))) as? (String, @escaping (Result<Void, Error>) -> Void) -> Void
+    open func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<LoginResponseContext, Error>) -> Void) {
+        addInvocation(.m_authenticateWithCode__phonephone_completioncompletion(Parameter<String>.value(`phone`), Parameter<(Result<LoginResponseContext, Error>) -> Void>.value(`completion`)))
+		let perform = methodPerformValue(.m_authenticateWithCode__phonephone_completioncompletion(Parameter<String>.value(`phone`), Parameter<(Result<LoginResponseContext, Error>) -> Void>.value(`completion`))) as? (String, @escaping (Result<LoginResponseContext, Error>) -> Void) -> Void
 		perform?(`phone`, `completion`)
     }
 
@@ -1502,6 +1537,18 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
         addInvocation(.m_requestAuthenticationCode__for_phonecompletion_completion(Parameter<String>.value(`phone`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`)))
 		let perform = methodPerformValue(.m_requestAuthenticationCode__for_phonecompletion_completion(Parameter<String>.value(`phone`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`))) as? (String, @escaping (Result<Void, Error>) -> Void) -> Void
 		perform?(`phone`, `completion`)
+    }
+
+    open func authenticateWithEmailCode(_ code: String, phone: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        addInvocation(.m_authenticateWithEmailCode__codephone_phonecompletion_completion(Parameter<String>.value(`code`), Parameter<String>.value(`phone`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`)))
+		let perform = methodPerformValue(.m_authenticateWithEmailCode__codephone_phonecompletion_completion(Parameter<String>.value(`code`), Parameter<String>.value(`phone`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`))) as? (String, String, @escaping (Result<Void, Error>) -> Void) -> Void
+		perform?(`code`, `phone`, `completion`)
+    }
+
+    open func resendEmailAuthCode(phone: String, deviceID: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        addInvocation(.m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>.value(`phone`), Parameter<String?>.value(`deviceID`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`)))
+		let perform = methodPerformValue(.m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>.value(`phone`), Parameter<String?>.value(`deviceID`), Parameter<(Result<Void, Error>) -> Void>.value(`completion`))) as? (String, String?, @escaping (Result<Void, Error>) -> Void) -> Void
+		perform?(`phone`, `deviceID`, `completion`)
     }
 
     open func setAPNSToken(_ token: Data) {
@@ -1513,8 +1560,10 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
 
     fileprivate enum MethodType {
         case m_logout
-        case m_authenticateWithCode__phonephone_completioncompletion(Parameter<String>, Parameter<(Result<Void, Error>) -> Void>)
+        case m_authenticateWithCode__phonephone_completioncompletion(Parameter<String>, Parameter<(Result<LoginResponseContext, Error>) -> Void>)
         case m_requestAuthenticationCode__for_phonecompletion_completion(Parameter<String>, Parameter<(Result<Void, Error>) -> Void>)
+        case m_authenticateWithEmailCode__codephone_phonecompletion_completion(Parameter<String>, Parameter<String>, Parameter<(Result<Void, Error>) -> Void>)
+        case m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(Parameter<String>, Parameter<String?>, Parameter<(Result<Void, Error>) -> Void>)
         case m_setAPNSToken__token(Parameter<Data>)
         case p_authenticationDelegate_get
 		case p_authenticationDelegate_set(Parameter<UserSessionAuthenticationDelegate?>)
@@ -1534,6 +1583,16 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
                 guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
                 guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
                 return true 
+            case (.m_authenticateWithEmailCode__codephone_phonecompletion_completion(let lhsCode, let lhsPhone, let lhsCompletion), .m_authenticateWithEmailCode__codephone_phonecompletion_completion(let rhsCode, let rhsPhone, let rhsCompletion)):
+                guard Parameter.compare(lhs: lhsCode, rhs: rhsCode, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
+                return true 
+            case (.m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(let lhsPhone, let lhsDeviceid, let lhsCompletion), .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(let rhsPhone, let rhsDeviceid, let rhsCompletion)):
+                guard Parameter.compare(lhs: lhsPhone, rhs: rhsPhone, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsDeviceid, rhs: rhsDeviceid, with: matcher) else { return false } 
+                guard Parameter.compare(lhs: lhsCompletion, rhs: rhsCompletion, with: matcher) else { return false } 
+                return true 
             case (.m_setAPNSToken__token(let lhsToken), .m_setAPNSToken__token(let rhsToken)):
                 guard Parameter.compare(lhs: lhsToken, rhs: rhsToken, with: matcher) else { return false } 
                 return true 
@@ -1551,6 +1610,8 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
             case .m_logout: return 0
             case let .m_authenticateWithCode__phonephone_completioncompletion(p0, p1): return p0.intValue + p1.intValue
             case let .m_requestAuthenticationCode__for_phonecompletion_completion(p0, p1): return p0.intValue + p1.intValue
+            case let .m_authenticateWithEmailCode__codephone_phonecompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
+            case let .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(p0, p1, p2): return p0.intValue + p1.intValue + p2.intValue
             case let .m_setAPNSToken__token(p0): return p0.intValue
             case .p_authenticationDelegate_get: return 0
 			case .p_authenticationDelegate_set(let newValue): return newValue.intValue
@@ -1588,8 +1649,10 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
         fileprivate var method: MethodType
 
         public static func logout() -> Verify { return Verify(method: .m_logout)}
-        public static func authenticateWithCode(phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_authenticateWithCode__phonephone_completioncompletion(`phone`, `completion`))}
+        public static func authenticateWithCode(phone: Parameter<String>, completion: Parameter<(Result<LoginResponseContext, Error>) -> Void>) -> Verify { return Verify(method: .m_authenticateWithCode__phonephone_completioncompletion(`phone`, `completion`))}
         public static func requestAuthenticationCode(for phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_requestAuthenticationCode__for_phonecompletion_completion(`phone`, `completion`))}
+        public static func authenticateWithEmailCode(_ code: Parameter<String>, phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_authenticateWithEmailCode__codephone_phonecompletion_completion(`code`, `phone`, `completion`))}
+        public static func resendEmailAuthCode(phone: Parameter<String>, deviceID: Parameter<String?>, completion: Parameter<(Result<Void, Error>) -> Void>) -> Verify { return Verify(method: .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(`phone`, `deviceID`, `completion`))}
         public static func setAPNSToken(_ token: Parameter<Data>) -> Verify { return Verify(method: .m_setAPNSToken__token(`token`))}
         public static var authenticationDelegate: Verify { return Verify(method: .p_authenticationDelegate_get) }
 		public static func authenticationDelegate(set newValue: Parameter<UserSessionAuthenticationDelegate?>) -> Verify { return Verify(method: .p_authenticationDelegate_set(newValue)) }
@@ -1605,11 +1668,17 @@ open class UserSessionProtocolMock: UserSessionProtocol, Mock {
         public static func logout(perform: @escaping () -> Void) -> Perform {
             return Perform(method: .m_logout, performs: perform)
         }
-        public static func authenticateWithCode(phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (String, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
+        public static func authenticateWithCode(phone: Parameter<String>, completion: Parameter<(Result<LoginResponseContext, Error>) -> Void>, perform: @escaping (String, @escaping (Result<LoginResponseContext, Error>) -> Void) -> Void) -> Perform {
             return Perform(method: .m_authenticateWithCode__phonephone_completioncompletion(`phone`, `completion`), performs: perform)
         }
         public static func requestAuthenticationCode(for phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (String, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
             return Perform(method: .m_requestAuthenticationCode__for_phonecompletion_completion(`phone`, `completion`), performs: perform)
+        }
+        public static func authenticateWithEmailCode(_ code: Parameter<String>, phone: Parameter<String>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (String, String, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
+            return Perform(method: .m_authenticateWithEmailCode__codephone_phonecompletion_completion(`code`, `phone`, `completion`), performs: perform)
+        }
+        public static func resendEmailAuthCode(phone: Parameter<String>, deviceID: Parameter<String?>, completion: Parameter<(Result<Void, Error>) -> Void>, perform: @escaping (String, String?, @escaping (Result<Void, Error>) -> Void) -> Void) -> Perform {
+            return Perform(method: .m_resendEmailAuthCode__phone_phonedeviceID_deviceIDcompletion_completion(`phone`, `deviceID`, `completion`), performs: perform)
         }
         public static func setAPNSToken(_ token: Parameter<Data>, perform: @escaping (Data) -> Void) -> Perform {
             return Perform(method: .m_setAPNSToken__token(`token`), performs: perform)

--- a/safetrace-sdk/Services/Session/UserSessionProtocol.swift
+++ b/safetrace-sdk/Services/Session/UserSessionProtocol.swift
@@ -19,7 +19,9 @@ public protocol SafeTraceSession {
     var isAuthenticated: Bool { get }
  
     func requestAuthenticationCode(for phone: String, completion: @escaping (Result<Void, Error>) -> Void)
-    func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<Void, Error>) -> Void)
+    func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<LoginResponseContext, Error>) -> Void)
+    func authenticateWithEmailCode(_ code: String, phone: String, completion: @escaping (Result<Void, Error>) -> Void)
+    func resendEmailAuthCode(phone: String, deviceID: String?, completion: @escaping (Result<Void, Error>) -> Void)
     func setAPNSToken(_ token: Data)
     func logout()
 }
@@ -34,5 +36,5 @@ protocol UserSessionProtocol: AnyObject, SafeTraceSession {
 
     func logout()
 
-    func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<Void, Error>) -> Void)
+    func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<LoginResponseContext, Error>) -> Void)
 }

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		3E0E3A22244C0085006520E4 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A21244C0085006520E4 /* Colors.swift */; };
 		3E0E3A24244C0886006520E4 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A23244C0886006520E4 /* Button.swift */; };
 		3E0E3A28244C1959006520E4 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A27244C1959006520E4 /* UIView+.swift */; };
+		3E5A05E8249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */; };
+		3E5A05E9249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */; };
 		3E5F6381244FDCF900C508A4 /* TappableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5F6380244FDCF900C508A4 /* TappableTextView.swift */; };
 		3E5F6383245209D900C508A4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5F6382245209D900C508A4 /* Constants.swift */; };
 		3E6A4509249ECD93001E94A8 /* PermissionImageLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6A4508249ECD93001E94A8 /* PermissionImageLabelView.swift */; };
@@ -177,6 +179,7 @@
 		3E0E3A21244C0085006520E4 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		3E0E3A23244C0886006520E4 /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		3E0E3A27244C1959006520E4 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationViewController.swift; sourceTree = "<group>"; };
 		3E5F6380244FDCF900C508A4 /* TappableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappableTextView.swift; sourceTree = "<group>"; };
 		3E5F6382245209D900C508A4 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		3E6A4508249ECD93001E94A8 /* PermissionImageLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionImageLabelView.swift; sourceTree = "<group>"; wrapsLines = 0; };
@@ -320,6 +323,7 @@
 				3E0E3A19244BFD41006520E4 /* IntroViewController.swift */,
 				DCD7482D2447D09E00B93256 /* PhoneEnterViewController.swift */,
 				3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */,
+				3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */,
 			);
 			path = "Auth Step";
 			sourceTree = "<group>";
@@ -812,6 +816,7 @@
 				3EE970BF244CBB2000AAF2CF /* TextField.swift in Sources */,
 				3E6A4510249EF627001E94A8 /* Update.swift in Sources */,
 				3EEFCB53249BCDDC00B74759 /* ContactTracingViewModel.swift in Sources */,
+				3E5A05E8249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */,
 				DC0E0FA92498273700D3C9FC /* OnboardingViewController.swift in Sources */,
 				3EE970CB244CEAA800AAF2CF /* PhoneVerificationViewController.swift in Sources */,
 				3E826849249EA6AC00B12FE3 /* SafeTraceProviding.swift in Sources */,
@@ -871,6 +876,7 @@
 				DC31D07C24994F7D0039FD6B /* Colors.swift in Sources */,
 				DC31D07D24994F7D0039FD6B /* BackButton.swift in Sources */,
 				DC31D07F24994F7D0039FD6B /* PhoneEnterViewController.swift in Sources */,
+				3E5A05E9249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */,
 				DCB94CCC249BC43D00D616AD /* DebugViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
- Added email verification flow
- Add error handling in network stack for if response code is between 400 and 600, so that wrong email and phone codes (which send back a 403 response code) will not be mistaken as success.