### PR TITLE
Redirect to citizen when successfully opting in

### DIFF
--- a/safetrace-app/Home/Contact Tracing/ContactTracingViewController.swift
+++ b/safetrace-app/Home/Contact Tracing/ContactTracingViewController.swift
@@ -95,6 +95,8 @@ class ContactTracingViewController: UIViewController {
             navigateToAppSettings: navigateToAppSettings,
             openWebView: openWebView,
             openCitizenAppOrAppStore: openCitizenAppOrAppStore,
+            optInSuccessChanged: optInSuccessChanged,
+            redirectToCitizen: redirectToCitizen,
             displayAlert: displayAlert
         ) = contactTracingViewModel(
             environment: environment,
@@ -170,7 +172,21 @@ class ContactTracingViewController: UIViewController {
         openCitizenAppOrAppStore
             .take(during: self.reactive.lifetime)
             .observe(on: UIScheduler())
-            .observeValues { [weak self] url in
+            .observeValues { [weak self] in
+                self?.environment.citizen.openSafepass()
+            }
+
+        optInSuccessChanged
+            .take(during: self.reactive.lifetime)
+            .observe(on: UIScheduler())
+            .observeValues { [weak self] isSuccess in
+                self?.environment.safeTrace.setLastSuccessfullyOptedIn(isSuccess)
+            }
+
+        redirectToCitizen
+            .take(during: self.reactive.lifetime)
+            .observe(on: UIScheduler())
+            .observeValues { [weak self] in
                 self?.environment.citizen.openSafepass()
             }
 

--- a/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
@@ -19,6 +19,14 @@ struct SafeTraceProvider: SafeTraceProviding {
         set { SafeTrace.apiEnvironment = newValue }
     }
 
+    func setLastSuccessfullyOptedIn(_ success: Bool) {
+        UserDefaults.standard.set(success, forKey: "org.ctzn.isLastSuccessfullyOptedIn")
+    }
+
+    func getLastSuccessfullyOptedIn() -> Bool {
+        return UserDefaults.standard.bool(forKey: "org.ctzn.isLastSuccessfullyOptedIn")
+    }
+
     func startTracing() {
         SafeTrace.startTracing()
     }

--- a/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
@@ -16,4 +16,7 @@ protocol SafeTraceProviding {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?)
     func applicationWillEnterForeground(_ application: UIApplication)
     func applicationDidEnterBackground(_ application: UIApplication)
+
+    func setLastSuccessfullyOptedIn(_ success: Bool)
+    func getLastSuccessfullyOptedIn() -> Bool
 }


### PR DESCRIPTION
Redirect to citizen when successfully opting in.
Only redirects at the moment you change from not successful to successful, so that we don't redirect you every time you land on the sidecar