### PR TITLE
Gao/fixes

### DIFF
--- a/safetrace-app/Home/Contact Tracing/ContactTracingViewModel.swift
+++ b/safetrace-app/Home/Contact Tracing/ContactTracingViewModel.swift
@@ -94,8 +94,10 @@ func contactTracingViewModel(
             viewDidLoad,
             appBecameActive
         )
+        .observe(on: QueueScheduler.main)
         .map { environment.citizen.isInstalled }
         .skipRepeats()
+
     // MARK: - View Data
 
     let viewData: Signal<ContactTracingViewData, Never> = Signal
@@ -140,6 +142,7 @@ func contactTracingViewModel(
         }
 
     let redirectToCitizen = optInSuccessChanged
+        .observe(on: QueueScheduler.main)
         .filter{
             $0
                 && environment.citizen.isInstalled

--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -84,6 +84,7 @@ public final class SafeTrace {
     public static func applicationWillEnterForeground(_ application: UIApplication) {
         environment.traceIDs.refreshIfNeeded()
         environment.tracer.reportPendingTraces()
+        environment.session.updateAuthTokenWebViewCookies(authToken: environment.session.authToken)
         sendHealthCheck()
     }
     

--- a/safetrace-sdk/Services/Session/UserSession.swift
+++ b/safetrace-sdk/Services/Session/UserSession.swift
@@ -176,10 +176,10 @@ class UserSession: UserSessionProtocol {
         self.authToken = token
         authenticationDelegate?.authenticationTokenDidChange(forSession: self)
 
-        updateAuthTokenWebViewCookie(authToken: token)
+        updateAuthTokenWebViewCookies(authToken: token)
     }
 
-    private func updateAuthTokenWebViewCookie(authToken: String?) {
+    func updateAuthTokenWebViewCookies(authToken: String?) {
         DispatchQueue.main.async {
             let authorizedCookieDict = [
                 ".sp0n.io": "citizen:auth:token",

--- a/safetrace-sdk/Services/Session/UserSessionProtocol.swift
+++ b/safetrace-sdk/Services/Session/UserSessionProtocol.swift
@@ -39,4 +39,5 @@ protocol UserSessionProtocol: AnyObject, SafeTraceSession {
     func logout()
 
     func authenticateWithCode(_: String, phone: String, completion: @escaping (Result<LoginResponseContext, Error>) -> Void)
+    func updateAuthTokenWebViewCookies(authToken: String?)
 }


### PR DESCRIPTION
- Quick fix to make sure `citizen.isIntalled()` is called on main thread
- Sync cookies each time on foregrounding app. This is easier for now so I don't have to import WebViewHelper and have each web view instance created in a completion block.