### PR TITLE
Move setFirstTimeDefaultIfNeeded to before attempting to log in using keychain

### DIFF
--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -88,7 +88,6 @@ public final class SafeTrace {
     /// foreground, or for background fetch activity, will initiate batch
     /// reporting and update the traceID cache.
     public static func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        setFirstTimeDefaultIfNeeded()
         if (launchOptions?[.bluetoothCentrals] != nil
             || launchOptions?[.bluetoothPeripherals] != nil) {
   
@@ -101,14 +100,6 @@ public final class SafeTrace {
             environment.tracer.reportPendingTraces()
             sendHealthCheck()
         }
-    }
-
-    /// Since we save userID and token on keychain, its persisted even if app is deleted
-    static func setFirstTimeDefaultIfNeeded() {
-        guard !UserDefaults.standard.bool(forKey: "org.ctzn.firstInstall") else { return }
-
-        UserDefaults.standard.set(true, forKey: "org.ctzn.firstInstall")
-        environment.session.logout()
     }
     
     public static func applicationWillEnterForeground(_ application: UIApplication) {

--- a/safetrace-sdk/Services/Session/UserSession.swift
+++ b/safetrace-sdk/Services/Session/UserSession.swift
@@ -79,6 +79,8 @@ class UserSession: UserSessionProtocol {
         self.environment = environment
         self.keychain = appKeychain
         self.groupKeychain = groupKeychain
+
+        setFirstTimeDefaultIfNeeded()
         attemptToLoadCachedValues()
         
         if !isAuthenticated {
@@ -243,6 +245,14 @@ class UserSession: UserSessionProtocol {
     
     private func getCachedUserID(from keychain: KeychainProtocol) -> String? {
         return keychain.get(userIDKeychainIdentifier)
+    }
+
+    /// Since we save userID and token on keychain, it's persisted even if app is deleted
+    private func setFirstTimeDefaultIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: "org.ctzn.firstInstall") else { return }
+
+        UserDefaults.standard.set(true, forKey: "org.ctzn.firstInstall")
+        logout()
     }
 }
 


### PR DESCRIPTION
So that after reinstalling app, it'll still fall back to the group keychain if it exists