### PR TITLE
Gao/bluetooth debugger

### DIFF
--- a/safetrace-app/Debug/BluetoothDebugDetailCell.swift
+++ b/safetrace-app/Debug/BluetoothDebugDetailCell.swift
@@ -1,0 +1,77 @@
+import SafeTrace
+import UIKit
+
+class BluetoothDebugDetailCell: UITableViewCell {
+    let scanDateLabel = UILabel()
+    let traceCreatedDateLabel = UILabel()
+    let uploadedDateLabel = UILabel()
+    let detailLabel = UILabel()
+    let errorLabel = UILabel()
+
+    let dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .short
+        dateFormatter.timeStyle = .short
+        return dateFormatter
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        scanDateLabel.font = .bodyBold
+        traceCreatedDateLabel.font = .bodyRegular
+        uploadedDateLabel.font = .bodyRegular
+        detailLabel.font = .bodyRegular
+        errorLabel.font = .bodyRegular
+
+        let stackView = UIStackView(arrangedSubviews: [
+            scanDateLabel,
+            traceCreatedDateLabel,
+            uploadedDateLabel,
+            detailLabel,
+            errorLabel
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 4
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(record: PeripheralRecord) {
+        scanDateLabel.text = "Detected: \(dateFormatter.string(from: record.scanDate))"
+
+        let traceCreatedDisplay = record.traceGeneratedDate != nil
+            ? dateFormatter.string(from: record.traceGeneratedDate!)
+            : "null"
+        traceCreatedDateLabel.text = "Trace Created: \(traceCreatedDisplay)"
+
+        let traceUploadedDisplay = record.traceUploadedDate != nil
+            ? dateFormatter.string(from: record.traceUploadedDate!)
+            : "null"
+        uploadedDateLabel.text = "Uploaded: \(traceUploadedDisplay)"
+
+        detailLabel.text = "RSSI: \(Int(record.rssi)) | Foreground: \(record.foreground) | Skipped: \(record.isSkipped)"
+
+        errorLabel.text = "Error: \(formatError(record.error))"
+    }
+
+    private func formatError(_ error: DebugTraceError?) -> String {
+        guard let error = error else {
+            return "None"
+        }
+
+        return "\(error.description) | \(error.context) | \(dateFormatter.string(from: error.createdDate))"
+    }
+}

--- a/safetrace-app/Debug/BluetoothDebugDetailViewController.swift
+++ b/safetrace-app/Debug/BluetoothDebugDetailViewController.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+class BluetoothDebugDetailViewController: UITableViewController {
+    private var records: [PeripheralRecord] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.register(BluetoothDebugDetailCell.self, forCellReuseIdentifier: String(describing: BluetoothDebugDetailCell.self))
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 100
+    }
+
+    func setRecords(records: [PeripheralRecord]) {
+        self.records = records
+        reload()
+    }
+
+    func reload() {
+        var name = records.first(where: { $0.name != nil })?.name ?? "null"
+        if let phoneModel = records.first(where: { $0.phoneModel != nil })?.phoneModel {
+            name += " [\(phoneModel)]"
+        }
+        navigationItem.title = name
+
+        tableView.reloadData()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        records.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let record = records[indexPath.row]
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: BluetoothDebugDetailCell.self), for: indexPath) as! BluetoothDebugDetailCell
+        cell.configure(record: record)
+
+        return cell
+    }
+}

--- a/safetrace-app/Debug/BluetoothDebugViewController.swift
+++ b/safetrace-app/Debug/BluetoothDebugViewController.swift
@@ -1,0 +1,315 @@
+import CoreBluetooth
+import SafeTrace
+import UIKit
+
+struct PeripheralDevice {
+    var name: String?
+    var count: Int
+    var averageRSSI: Int
+    var averageDiscoveryInterval: Double?
+    var lastDiscoveryDate: Date
+    var skippedCount: Int
+    var tracesCreated: Int
+    var tracesUploaded: Int
+    var errorCount: Int
+    var phoneModel: String?
+    var lastUploadedDate: Date?
+
+    init(records: [PeripheralRecord]) {
+        if records.isEmpty {
+            assertionFailure("records cannot be empty")
+        }
+
+        let count = records.count
+
+        var totalRSSI: Int = 0
+        var totalInterval: Double = 0
+        var name: String?
+
+        for (index, record) in records.enumerated() {
+            totalRSSI += record.rssi
+
+            if
+                name == nil,
+                let peripheralName = record.name
+            {
+                name = peripheralName
+            }
+
+            if index >= 1 {
+                let lastRecord = records[index - 1]
+                let scanInterval = record.scanDate.timeIntervalSince1970 - lastRecord.scanDate.timeIntervalSince1970
+                totalInterval += scanInterval
+            }
+        }
+
+        self.name = name
+        self.count = count
+        self.averageRSSI = count > 0
+            ? totalRSSI / count
+            : 0
+        self.averageDiscoveryInterval = count > 1
+            ? totalInterval / Double(count - 1)
+            : nil
+        self.lastDiscoveryDate = records.last!.scanDate
+
+        let uploads = records.filter { $0.traceUploadedDate != nil }
+
+        self.lastUploadedDate = uploads.last?.traceUploadedDate
+        self.skippedCount = records.filter { $0.isSkipped }.count
+        self.tracesCreated = records.filter { $0.traceGeneratedDate != nil }.count
+        self.tracesUploaded = uploads.count
+        self.errorCount = records.filter { $0.error != nil }.count
+        self.phoneModel = records.first(where: { $0.phoneModel != nil })?.phoneModel
+    }
+}
+
+class PeripheralRecord {
+    // Scan info
+    var name: String?
+    var rssi: Int
+    var isSkipped: Bool
+    var foreground: Bool
+    var scanDate: Date
+
+    // Trace info
+    var traceGeneratedDate: Date?
+    var phoneModel: String?
+
+    // Upload info
+    var traceUploadedDate: Date?
+
+    // Error info
+    var error: DebugTraceError?
+
+    init(
+        name: String?,
+        rssi: Int,
+        isSkipped: Bool,
+        foreground: Bool,
+        scanDate: Date
+    ) {
+        self.name = name
+        self.rssi = rssi
+        self.isSkipped = isSkipped
+        self.foreground = foreground
+        self.scanDate = scanDate
+    }
+}
+
+class BluetoothDebugViewController: UITableViewController {
+
+    let dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .short
+        dateFormatter.timeStyle = .short
+        return dateFormatter
+    }()
+
+    var debugPeripheralsByUUID = [UUID: [DebugDiscoveredPeripheral]]()
+    var debugTracesByUUID = [UUID: [DebugTrace]]()
+    var debugTraceUploadsByUUID = [UUID: [DebugTraceUpload]]()
+    var debugTraceErrorsByUUID = [UUID: [DebugTraceError]]()
+
+    var traceIDMap = [String: UUID]()
+
+    var displayData = [PeripheralDevice]()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+//        Debug.clearDebugRecords()
+
+        // Import existing traces
+        addPeripheralDiscoveries(Debug.debugPeripherals)
+        Debug.debugPeripheralHandler = { [weak self] discovery in
+            self?.addPeripheralDiscoveries([discovery])
+            self?.processAndReloadData()
+        }
+
+        addTraces(Debug.debugTraces)
+        Debug.debugTraceHandler = {[weak self] trace in
+            self?.addTraces([trace])
+            self?.processAndReloadData()
+        }
+
+        addTraceErrors(Debug.traceErrors)
+        Debug.traceErrorHandler = { [weak self] error in
+            self?.addTraceErrors([error])
+            self?.processAndReloadData()
+        }
+
+        addTraceUploads(Debug.traceUploads)
+        Debug.tracesUploadedHandler = { [weak self] uploads in
+            self?.addTraceUploads(uploads)
+            self?.processAndReloadData()
+        }
+
+        processAndReloadData()
+    }
+
+    // MARK: - Helper functions
+
+    private func addPeripheralDiscoveries(_ discoveries: [DebugDiscoveredPeripheral]) {
+        discoveries.forEach { discovery in
+            let uuid = discovery.peripheral.identifier
+            if var discoveriesForDevice = debugPeripheralsByUUID[uuid] {
+                discoveriesForDevice.append(discovery)
+                debugPeripheralsByUUID[uuid] = discoveriesForDevice
+            } else {
+                debugPeripheralsByUUID[uuid] = [discovery]
+            }
+        }
+    }
+
+    private func addTraces(_ traces: [DebugTrace]) {
+        traces.forEach { trace in
+            let uuid = trace.peripheralUUID
+            traceIDMap[trace.traceID] = uuid
+            if var tracesForDevice = debugTracesByUUID[uuid] {
+                tracesForDevice.append(trace)
+                debugTracesByUUID[uuid] = tracesForDevice
+            } else {
+                debugTracesByUUID[uuid] = [trace]
+            }
+        }
+    }
+
+    private func addTraceErrors(_ errors: [DebugTraceError]) {
+        errors.forEach { error in
+            let uuid = error.peripheralUUID
+            if var errorsForDevice = debugTraceErrorsByUUID[uuid] {
+                errorsForDevice.append(error)
+                debugTraceErrorsByUUID[uuid] = errorsForDevice
+            } else {
+                debugTraceErrorsByUUID[uuid] = [error]
+            }
+        }
+    }
+
+    private func addTraceUploads(_ uploads: [DebugTraceUpload]) {
+        for upload in uploads {
+            let id = upload.traceID
+            if let uuid = traceIDMap[id] {
+                if var uploadsForDevice = debugTraceUploadsByUUID[uuid] {
+                    uploadsForDevice.append(upload)
+                    debugTraceUploadsByUUID[uuid] = uploadsForDevice
+                } else {
+                    debugTraceUploadsByUUID[uuid] = [upload]
+                }
+            } else {
+                print("ERROR: Could not find matching trace for upload")
+            }
+        }
+    }
+
+    private func processAndReloadData() {
+        DispatchQueue.main.async {
+            self.displayData = []
+            for (uuid, discoveries) in self.debugPeripheralsByUUID {
+
+                let baseRecords = discoveries.map {
+                    PeripheralRecord(
+                        name: $0.peripheral.name,
+                        rssi: $0.rssi,
+                        isSkipped: $0.isSkipped,
+                        foreground: $0.foreground,
+                        scanDate: $0.scanDate
+                    )
+                }
+
+                // Hydrate discoveries
+
+                var recordIndex = 0
+                var traceIndex = 0
+                var errorIndex = 0
+                var uploadIndex = 0
+
+                while recordIndex < baseRecords.count {
+                    let currentRecord = baseRecords[recordIndex]
+                    let nextRecord = recordIndex < baseRecords.count - 1
+                        ? baseRecords[recordIndex + 1]
+                        : nil
+
+                    if let traces = self.debugTracesByUUID[uuid], traceIndex < traces.count {
+                        let currentTrace = traces[traceIndex]
+                        let timestamp = currentTrace.createdDate
+
+                        if let nextRecord = nextRecord, nextRecord.scanDate < timestamp {
+                            // do not attribute trace to this record
+                        } else {
+                            currentRecord.traceGeneratedDate = currentTrace.createdDate
+                            traceIndex += 1
+                        }
+                    }
+
+                    if let uploads = self.debugTraceUploadsByUUID[uuid], uploadIndex < uploads.count {
+                        let currentUpload = uploads[uploadIndex]
+                        if currentRecord.traceGeneratedDate == currentUpload.createdDate {
+                            currentRecord.traceUploadedDate = currentUpload.uploadedDate
+                            uploadIndex += 1
+                        }
+                    }
+
+                    if let errors = self.debugTraceErrorsByUUID[uuid], errorIndex < errors.count {
+                        let currentError = errors[errorIndex]
+                        let timestamp = currentError.createdDate
+
+                        if let nextRecord = nextRecord, nextRecord.scanDate < timestamp {
+                            // do not attribute error to this record
+                        } else {
+                            currentRecord.error = currentError
+                            errorIndex += 1
+                        }
+                    }
+
+                    recordIndex += 1
+                }
+
+                let peripheralDevice = PeripheralDevice(records: baseRecords)
+                self.displayData.append(peripheralDevice)
+            }
+            self.displayData = self.displayData.sorted { $0.lastDiscoveryDate > $1.lastDiscoveryDate }
+            self.tableView.reloadData()
+        }
+    }
+}
+
+extension BluetoothDebugViewController {
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // TODO
+
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        displayData.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let peripheral = displayData[indexPath.row]
+
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "cell")
+
+        var title = peripheral.name ?? "null"
+        if let phoneModel = peripheral.phoneModel {
+            title += " [\(phoneModel)]"
+        }
+        title += " (\(peripheral.count) / \(peripheral.tracesCreated) / \(peripheral.tracesUploaded) / \(peripheral.errorCount) / \(peripheral.skippedCount))"
+        cell.textLabel?.text = title
+
+        let displayInterval = peripheral.averageDiscoveryInterval != nil
+            ? "\(Int(peripheral.averageDiscoveryInterval!))"
+            : "n/a"
+        let subtitle = "RSSI: \(Int(peripheral.averageRSSI)) | Interval: \(displayInterval) s | Updated: \(dateFormatter.string(from: peripheral.lastDiscoveryDate))"
+        cell.detailTextLabel?.text = subtitle
+
+        return cell
+    }
+
+}

--- a/safetrace-app/Debug/BluetoothDebugViewController.swift
+++ b/safetrace-app/Debug/BluetoothDebugViewController.swift
@@ -259,6 +259,7 @@ class BluetoothDebugViewController: UITableViewController {
                             // do not attribute trace to this record
                         } else {
                             currentRecord.traceGeneratedDate = currentTrace.createdDate
+                            currentRecord.phoneModel = currentTrace.phoneModel
                             traceIndex += 1
                         }
                     }

--- a/safetrace-app/Debug/BluetoothDebugViewController.swift
+++ b/safetrace-app/Debug/BluetoothDebugViewController.swift
@@ -16,6 +16,8 @@ struct PeripheralDevice {
     var lastUploadedDate: Date?
     var lastUpdatedDate: Date
 
+    var records: [PeripheralRecord]
+
     init(records: [PeripheralRecord]) {
         if records.isEmpty {
             assertionFailure("records cannot be empty")
@@ -68,6 +70,7 @@ struct PeripheralDevice {
         } else {
             self.lastUpdatedDate = lastDiscoveryDate
         }
+        self.records = records
     }
 }
 
@@ -320,7 +323,11 @@ extension BluetoothDebugViewController {
     // MARK: - UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO
+        let records = displayData[indexPath.row].records
+        let detailVC = BluetoothDebugDetailViewController()
+        detailVC.setRecords(records: records)
+
+        navigationController?.pushViewController(detailVC, animated: true)
 
         tableView.deselectRow(at: indexPath, animated: true)
     }

--- a/safetrace-app/Debug/BluetoothDebugViewController.swift
+++ b/safetrace-app/Debug/BluetoothDebugViewController.swift
@@ -106,46 +106,66 @@ class BluetoothDebugViewController: UITableViewController {
         return dateFormatter
     }()
 
-    var debugPeripheralsByUUID = [UUID: [DebugDiscoveredPeripheral]]()
-    var debugTracesByUUID = [UUID: [DebugTrace]]()
-    var debugTraceUploadsByUUID = [UUID: [DebugTraceUpload]]()
-    var debugTraceErrorsByUUID = [UUID: [DebugTraceError]]()
+    private var debugPeripheralsByUUID = [UUID: [DebugDiscoveredPeripheral]]()
+    private var debugTracesByUUID = [UUID: [DebugTrace]]()
+    private var debugTraceUploadsByUUID = [UUID: [DebugTraceUpload]]()
+    private var debugTraceErrorsByUUID = [UUID: [DebugTraceError]]()
 
-    var traceIDMap = [String: UUID]()
+    private var traceIDMap = [String: UUID]()
 
-    var displayData = [PeripheralDevice]()
+    private var displayData = [PeripheralDevice]()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-//        Debug.clearDebugRecords()
+        navigationItem.title = "Bluetooth Debugger"
+        navigationItem.leftBarButtonItem = .init(title: "Clear", style: .plain, target: self, action: #selector(clearRecords))
+        navigationItem.rightBarButtonItem = .init(title: "Close", style: .done, target: self, action: #selector(dismissVC))
 
-        // Import existing traces
-        addPeripheralDiscoveries(Debug.debugPeripherals)
+        initialLoad()
+
         Debug.debugPeripheralHandler = { [weak self] discovery in
             self?.addPeripheralDiscoveries([discovery])
             self?.processAndReloadData()
         }
-
-        addTraces(Debug.debugTraces)
         Debug.debugTraceHandler = {[weak self] trace in
             self?.addTraces([trace])
             self?.processAndReloadData()
         }
-
-        addTraceErrors(Debug.traceErrors)
         Debug.traceErrorHandler = { [weak self] error in
             self?.addTraceErrors([error])
             self?.processAndReloadData()
         }
-
-        addTraceUploads(Debug.traceUploads)
         Debug.tracesUploadedHandler = { [weak self] uploads in
             self?.addTraceUploads(uploads)
             self?.processAndReloadData()
         }
+    }
+
+    private func initialLoad() {
+        // Import existing traces
+        addPeripheralDiscoveries(Debug.debugPeripherals)
+        addTraces(Debug.debugTraces)
+        addTraceErrors(Debug.traceErrors)
+        addTraceUploads(Debug.traceUploads)
 
         processAndReloadData()
+    }
+
+    @objc private func clearRecords() {
+        Debug.clearDebugRecords()
+
+        debugPeripheralsByUUID = [:]
+        debugTracesByUUID = [:]
+        debugTraceUploadsByUUID = [:]
+        debugTraceErrorsByUUID = [:]
+        traceIDMap = [:]
+
+        initialLoad()
+    }
+
+    @objc private func dismissVC() {
+        self.dismiss(animated: true)
     }
 
     // MARK: - Helper functions

--- a/safetrace-app/Debug/BluetoothDebugViewController.swift
+++ b/safetrace-app/Debug/BluetoothDebugViewController.swift
@@ -14,6 +14,7 @@ struct PeripheralDevice {
     var errorCount: Int
     var phoneModel: String?
     var lastUploadedDate: Date?
+    var lastUpdatedDate: Date
 
     init(records: [PeripheralRecord]) {
         if records.isEmpty {
@@ -61,6 +62,12 @@ struct PeripheralDevice {
         self.tracesUploaded = uploads.count
         self.errorCount = records.filter { $0.error != nil }.count
         self.phoneModel = records.first(where: { $0.phoneModel != nil })?.phoneModel
+
+        if let lastUploadedDate = lastUploadedDate, lastUploadedDate > lastDiscoveryDate {
+            self.lastUpdatedDate = lastUploadedDate
+        } else {
+            self.lastUpdatedDate = lastDiscoveryDate
+        }
     }
 }
 
@@ -327,7 +334,7 @@ extension BluetoothDebugViewController {
         let displayInterval = peripheral.averageDiscoveryInterval != nil
             ? "\(Int(peripheral.averageDiscoveryInterval!))"
             : "n/a"
-        let subtitle = "RSSI: \(Int(peripheral.averageRSSI)) | Interval: \(displayInterval) s | Updated: \(dateFormatter.string(from: peripheral.lastDiscoveryDate))"
+        let subtitle = "RSSI: \(Int(peripheral.averageRSSI)) | Interval: \(displayInterval) s | Updated: \(dateFormatter.string(from: peripheral.lastUpdatedDate))"
         cell.detailTextLabel?.text = subtitle
 
         return cell

--- a/safetrace-app/Debug/DebugViewController.swift
+++ b/safetrace-app/Debug/DebugViewController.swift
@@ -86,8 +86,10 @@ internal final class DebugViewController: UIViewController {
     }
 
     @objc private func openDebugger() {
-        let debugVC = BluetoothDebugViewController()
-        present(debugVC, animated: true, completion: nil)
+        let vc = BluetoothDebugViewController()
+        let navVC = UINavigationController(rootViewController: vc)
+        navVC.modalPresentationStyle = .fullScreen
+        present(navVC, animated: true, completion: nil)
     }
     
     required init?(coder: NSCoder) {

--- a/safetrace-app/Debug/DebugViewController.swift
+++ b/safetrace-app/Debug/DebugViewController.swift
@@ -39,14 +39,21 @@ internal final class DebugViewController: UIViewController {
             debugSwitch
         ])
 
-        let logoutButton = UIButton(type: .system)
+        let logoutButton = Button(style: .secondary, size: .small)
+        logoutButton.contentEdgeInsets = .init(top: 0, left: 16, bottom: 0, right: 16)
         logoutButton.setTitle("Logout", for: .normal)
         logoutButton.addTarget(self, action: #selector(logout), for: .touchUpInside)
+
+        let debuggerButton = Button(style: .primary, size: .small)
+        debuggerButton.contentEdgeInsets = .init(top: 0, left: 16, bottom: 0, right: 16)
+        debuggerButton.setTitle("Open Debugger", for: .normal)
+        debuggerButton.addTarget(self, action: #selector(openDebugger), for: .touchUpInside)
 
         let mainStackView = UIStackView(arrangedSubviews: [
             envStackView,
             debugStackView,
-            logoutButton
+            logoutButton,
+            debuggerButton
         ])
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.axis = .vertical
@@ -76,6 +83,11 @@ internal final class DebugViewController: UIViewController {
     @objc private func logout() {
         SafeTrace.session.logout()
         fatalError()
+    }
+
+    @objc private func openDebugger() {
+        let debugVC = BluetoothDebugViewController()
+        present(debugVC, animated: true, completion: nil)
     }
     
     required init?(coder: NSCoder) {

--- a/safetrace-sdk/Trace/ContactTracer.swift
+++ b/safetrace-sdk/Trace/ContactTracer.swift
@@ -122,6 +122,7 @@ internal final class ContactTracer: NSObject {
             switch result {
             case .success:
                 success?()
+                Debug.recordTraceUploads(traces)
             case .failure(let error):
                 self?.logError(error.localizedDescription, context: "uploadTraces", meta: nil)
             }

--- a/safetrace-sdk/Utility/Debug.swift
+++ b/safetrace-sdk/Utility/Debug.swift
@@ -31,7 +31,7 @@ public struct DebugDiscoveredPeripheral: Codable {
     public var scanDate: Date
 }
 
-public struct DebugTrace: Codable {
+public struct DebugTrace: Codable, Hashable {
     public var peripheralUUID: UUID
     public var traceID: String
     public var senderForeground: Bool

--- a/safetrace-sdk/Utility/Debug.swift
+++ b/safetrace-sdk/Utility/Debug.swift
@@ -1,11 +1,85 @@
+import CoreBluetooth
 import Foundation
+import UIKit
 import UserNotifications
 
 internal let debugNotifsDefaultsIdentifier = "org.ctzn.debug_notifications"
 private var debugNotificationsEnabled = UserDefaults.standard.bool(forKey: debugNotifsDefaultsIdentifier)
 
-internal enum Debug {
-    
+private let peripheralDiscoveriesIdentifier = "org.ctzn.debug_discoveries"
+private let debugTracesIdentifier = "org.ctzn.debug_traces"
+private let debugTraceUploadsIdentifier = "org.ctzn.debug_trace_uploads"
+private let debugTraceErrorsIdentifier = "org.ctzn.debug_trace_errors"
+
+public struct DebugPeripheral: Codable {
+    public var identifier: UUID
+    public var name: String?
+
+    init(peripheral: CBPeripheral) {
+        self.identifier = peripheral.identifier
+        self.name = peripheral.name
+    }
+}
+
+public struct DebugDiscoveredPeripheral: Codable {
+    public var peripheral: DebugPeripheral
+    public var rssi: Int
+    public var nameCharacteristic: String?
+    public var uuidCharacteristic: [String]?
+    public var isSkipped: Bool
+    public var foreground: Bool
+    public var scanDate: Date
+}
+
+public struct DebugTrace: Codable {
+    public var peripheralUUID: UUID
+    public var traceID: String
+    public var senderForeground: Bool
+    public var phoneModel: String
+    public var createdDate: Date
+}
+
+public struct DebugTraceError: Codable {
+    public var peripheralUUID: UUID
+    public var description: String
+    public var context: String
+    public var createdDate: Date
+}
+
+public struct DebugTraceUpload: Codable {
+    public var traceID: String
+    public var createdDate: Date
+    public var uploadedDate: Date
+}
+
+public enum Debug {
+
+    public static var debugPeripherals: [DebugDiscoveredPeripheral] = loadDiscoveredPeripherals()
+    public static var debugPeripheralHandler: ((DebugDiscoveredPeripheral) -> Void)?
+
+    public static var debugTraces: [DebugTrace] = loadDebugTraces()
+    public static var debugTraceHandler: ((DebugTrace) -> Void)?
+
+    public static var traceUploads: [DebugTraceUpload] = loadTraceUploads()
+    public static var tracesUploadedHandler: (([DebugTraceUpload]) -> Void)?
+
+    public static var traceErrors: [DebugTraceError] = loadTraceErrors()
+    public static var traceErrorHandler: ((DebugTraceError) -> Void)?
+
+
+    // MARK: Clear Debug Records
+
+    public static func clearDebugRecords() {
+        #if INTERNAL
+        saveDiscoveredPeripherals([])
+        saveDebugTraces([])
+        saveTracesUploads([])
+        saveTracesErrors([])
+        #endif
+    }
+
+    // MARK: Notifications
+
     static var notificationsEnabled: Bool {
         get {
             return debugNotificationsEnabled
@@ -31,5 +105,169 @@ internal enum Debug {
 
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
         UNUserNotificationCenter.current().add(request) { _ in }
+    }
+
+    // MARK: - Debugger Peripheral Discovery
+
+    static func recordPeripheralDiscovery(_ peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber, isSkipped: Bool) {
+        #if INTERNAL
+        let nameCharacteristic = advertisementData[CBAdvertisementDataLocalNameKey] as? String
+        let uuidCharacteristic = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.map { $0.uuidString }
+
+        let peripheralDiscovery = DebugDiscoveredPeripheral(
+            peripheral: .init(peripheral: peripheral),
+            rssi: RSSI.intValue,
+            nameCharacteristic: nameCharacteristic,
+            uuidCharacteristic: uuidCharacteristic,
+            isSkipped: isSkipped,
+            foreground: UIApplication.shared.applicationState == .active,
+            scanDate: Date()
+        )
+
+        debugPeripherals.append(peripheralDiscovery)
+        debugPeripheralHandler?(peripheralDiscovery)
+
+        saveDiscoveredPeripherals(debugPeripherals)
+        #endif
+    }
+
+    private static func saveDiscoveredPeripherals(_ data: [DebugDiscoveredPeripheral]) {
+        guard let json = try? JSONEncoder().encode(data) else {
+            assertionFailure("Could not serialize debug peripheral data")
+            return
+        }
+
+        UserDefaults.standard.set(json, forKey: peripheralDiscoveriesIdentifier)
+    }
+
+    private static func loadDiscoveredPeripherals() -> [DebugDiscoveredPeripheral] {
+        if let json = UserDefaults.standard.data(forKey: peripheralDiscoveriesIdentifier),
+            let discoveries = try? JSONDecoder().decode([DebugDiscoveredPeripheral].self, from: json) {
+
+            return discoveries
+        }
+
+        return []
+    }
+
+    // MARK: Debugger Trace Creation
+
+    static func recordTraceCreation(_ packet: TracePacket, peripheral: CBPeripheral, timestamp: Date) {
+        #if INTERNAL
+        let trace = DebugTrace(
+            peripheralUUID: peripheral.identifier,
+            traceID: packet.traceID,
+            senderForeground: packet.foreground,
+            phoneModel: packet.phoneModel,
+            createdDate: timestamp
+        )
+
+        debugTraces.append(trace)
+        debugTraceHandler?(trace)
+
+        saveDebugTraces(debugTraces)
+        #endif
+    }
+
+    private static func saveDebugTraces(_ data: [DebugTrace]) {
+        guard let json = try? JSONEncoder().encode(data) else {
+            assertionFailure("Could not serialize debug trace")
+            return
+        }
+
+        UserDefaults.standard.set(json, forKey: debugTracesIdentifier)
+    }
+
+    private static func loadDebugTraces() -> [DebugTrace] {
+        if let json = UserDefaults.standard.data(forKey: debugTracesIdentifier),
+            let traces = try? JSONDecoder().decode([DebugTrace].self, from: json) {
+
+            return traces
+        }
+
+        return []
+    }
+
+    // MARK: Debugger Trace Uploads
+
+    static func recordTraceUploads(_ traces: [ContactTrace]) {
+        #if INTERNAL
+        let uploadedDate = Date()
+
+        let uploads = traces.map {
+            DebugTraceUpload(
+                traceID: $0.sender.traceID,
+                createdDate: $0.receiver.timestamp,
+                uploadedDate: uploadedDate
+            )
+        }
+
+        traceUploads.append(contentsOf: uploads)
+        tracesUploadedHandler?(uploads)
+
+        saveTracesUploads(traceUploads)
+        #endif
+    }
+
+    private static func saveTracesUploads(_ data: [DebugTraceUpload]) {
+        guard let json = try? JSONEncoder().encode(data) else {
+            assertionFailure("Could not serialize debug trace uploads")
+            return
+        }
+
+        UserDefaults.standard.set(json, forKey: debugTraceUploadsIdentifier)
+    }
+
+    private static func loadTraceUploads() -> [DebugTraceUpload] {
+        if let json = UserDefaults.standard.data(forKey: debugTraceUploadsIdentifier),
+            let uploads = try? JSONDecoder().decode([DebugTraceUpload].self, from: json) {
+
+            return uploads
+        }
+
+        return []
+    }
+
+    // MARK: Debugger Trace Errors
+
+    static func recordTraceError(_ error: String, context: String, peripheral: CBPeripheral) {
+        #if INTERNAL
+        let error = DebugTraceError(
+            peripheralUUID: peripheral.identifier,
+            description: error,
+            context: context,
+            createdDate: Date()
+        )
+
+        traceErrors.append(error)
+        traceErrorHandler?(error)
+
+        saveTracesErrors(traceErrors)
+        #endif
+    }
+
+    private static func saveTracesErrors(_ data: [DebugTraceError]) {
+        guard let json = try? JSONEncoder().encode(data) else {
+            assertionFailure("Could not serialize debug trace error")
+            return
+        }
+
+        UserDefaults.standard.set(json, forKey: debugTraceErrorsIdentifier)
+    }
+
+    private static func loadTraceErrors() -> [DebugTraceError] {
+        if let json = UserDefaults.standard.data(forKey: debugTraceErrorsIdentifier),
+            let errors = try? JSONDecoder().decode([DebugTraceError].self, from: json) {
+
+            return errors
+        }
+
+        return []
+    }
+
+    // MARK: - Record being read from another device
+
+    static func recordDebugPeripheralReadRequest() {
+        // TODO
     }
 }

--- a/safetrace-sdk/Utility/Debug.swift
+++ b/safetrace-sdk/Utility/Debug.swift
@@ -71,6 +71,11 @@ public enum Debug {
 
     public static func clearDebugRecords() {
         #if INTERNAL
+        debugPeripherals = []
+        debugTraces = []
+        traceUploads = []
+        traceErrors = []
+
         saveDiscoveredPeripherals([])
         saveDebugTraces([])
         saveTracesUploads([])

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		3EB4386D249D4A4200AA80DF /* Reactive+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB4386B249D4A4200AA80DF /* Reactive+.swift */; };
 		3EBA763124C64DC4005F3597 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */; };
 		3EBA763224C64DC4005F3597 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */; };
+		3ED5586124C8F15200B97155 /* BluetoothDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED5586024C8F15200B97155 /* BluetoothDebugViewController.swift */; };
 		3EE970BF244CBB2000AAF2CF /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970BE244CBB2000AAF2CF /* TextField.swift */; };
 		3EE970CB244CEAA800AAF2CF /* PhoneVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */; };
 		3EEFCB4D249AC5B800B74759 /* ContactTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */; };
@@ -97,7 +98,7 @@
 		DC31D07C24994F7D0039FD6B /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A21244C0085006520E4 /* Colors.swift */; };
 		DC31D07D24994F7D0039FD6B /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F972498261700D3C9FC /* BackButton.swift */; };
 		DC31D07F24994F7D0039FD6B /* PhoneEnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD7482D2447D09E00B93256 /* PhoneEnterViewController.swift */; };
-		DC31D08124994F7D0039FD6B /* SafeTrace.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC0BBB1224468E5B00B18911 /* SafeTrace.framework */; };
+		DC31D08124994F7D0039FD6B /* SafeTrace.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC0BBB1224468E5B00B18911 /* SafeTrace.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		DC31D08324994F7D0039FD6B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC0BBB4824469C9C00B18911 /* LaunchScreen.storyboard */; };
 		DC31D08424994F7D0039FD6B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC0BBB4624469C9C00B18911 /* Assets.xcassets */; };
 		DC31D08624994F7D0039FD6B /* SafeTrace.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DC0BBB1224468E5B00B18911 /* SafeTrace.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -118,7 +119,6 @@
 		DC897BA52450F65F00C80DF9 /* BluetoothCentralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC897BA42450F65F00C80DF9 /* BluetoothCentralTests.swift */; };
 		DCA29A06244B912F0074CD29 /* PhoneEnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD7482D2447D09E00B93256 /* PhoneEnterViewController.swift */; };
 		DCB94CC9249BC03300D616AD /* UIWindow+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB94CC7249BC02500D616AD /* UIWindow+Debug.swift */; };
-		DCB94CCB249BC43200D616AD /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB94CCA249BC43200D616AD /* DebugViewController.swift */; };
 		DCB94CCC249BC43D00D616AD /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB94CCA249BC43200D616AD /* DebugViewController.swift */; };
 		DCB94CCE249D62DC00D616AD /* UIApplication+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB94CCD249D62DC00D616AD /* UIApplication+Version.swift */; };
 		DCB94CD0249D651800D616AD /* Data+HexString.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB94CCF249D651700D616AD /* Data+HexString.swift */; };
@@ -215,6 +215,7 @@
 		3EB43868249D125500AA80DF /* NotificationPermissionsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionsProviding.swift; sourceTree = "<group>"; };
 		3EB4386B249D4A4200AA80DF /* Reactive+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reactive+.swift"; sourceTree = "<group>"; };
 		3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvents.swift; sourceTree = "<group>"; };
+		3ED5586024C8F15200B97155 /* BluetoothDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothDebugViewController.swift; sourceTree = "<group>"; };
 		3EE970BE244CBB2000AAF2CF /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 		3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerificationViewController.swift; sourceTree = "<group>"; };
 		3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTracingViewController.swift; sourceTree = "<group>"; };
@@ -599,6 +600,7 @@
 			children = (
 				DCB94CC7249BC02500D616AD /* UIWindow+Debug.swift */,
 				DCB94CCA249BC43200D616AD /* DebugViewController.swift */,
+				3ED5586024C8F15200B97155 /* BluetoothDebugViewController.swift */,
 			);
 			path = Debug;
 			sourceTree = "<group>";
@@ -865,7 +867,6 @@
 				DC0E0FA72498271F00D3C9FC /* OnboardingStep.swift in Sources */,
 				DC0E0FAB2498274B00D3C9FC /* AuthOnboardingStep.swift in Sources */,
 				3E5A060224A143AB0052A242 /* CitizenProviding.swift in Sources */,
-				DCB94CCB249BC43200D616AD /* DebugViewController.swift in Sources */,
 				3E5A05F824A1354F0052A242 /* ReportTestResultView.swift in Sources */,
 				3E0E3A1A244BFD41006520E4 /* IntroViewController.swift in Sources */,
 				3E5A05F424A1194E0052A242 /* SeparatorView.swift in Sources */,
@@ -943,6 +944,7 @@
 				3E5A05FF24A13F070052A242 /* TappableView.swift in Sources */,
 				DC31D07B24994F7D0039FD6B /* UIView+.swift in Sources */,
 				DC31D07C24994F7D0039FD6B /* Colors.swift in Sources */,
+				3ED5586124C8F15200B97155 /* BluetoothDebugViewController.swift in Sources */,
 				DC31D07D24994F7D0039FD6B /* BackButton.swift in Sources */,
 				DC31D07F24994F7D0039FD6B /* PhoneEnterViewController.swift in Sources */,
 				3E5A05E9249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */,

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E09C8B424CF662A00D65EF4 /* BluetoothDebugDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E09C8B324CF662A00D65EF4 /* BluetoothDebugDetailViewController.swift */; };
+		3E09C8B624CF6B3700D65EF4 /* BluetoothDebugDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E09C8B524CF6B3700D65EF4 /* BluetoothDebugDetailCell.swift */; };
 		3E0E3A1A244BFD41006520E4 /* IntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A19244BFD41006520E4 /* IntroViewController.swift */; };
 		3E0E3A20244BFFA4006520E4 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A1F244BFFA4006520E4 /* Fonts.swift */; };
 		3E0E3A22244C0085006520E4 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A21244C0085006520E4 /* Colors.swift */; };
@@ -192,6 +194,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3E09C8B324CF662A00D65EF4 /* BluetoothDebugDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothDebugDetailViewController.swift; sourceTree = "<group>"; };
+		3E09C8B524CF6B3700D65EF4 /* BluetoothDebugDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothDebugDetailCell.swift; sourceTree = "<group>"; };
 		3E0E3A19244BFD41006520E4 /* IntroViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewController.swift; sourceTree = "<group>"; };
 		3E0E3A1F244BFFA4006520E4 /* Fonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
 		3E0E3A21244C0085006520E4 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
@@ -601,6 +605,8 @@
 				DCB94CC7249BC02500D616AD /* UIWindow+Debug.swift */,
 				DCB94CCA249BC43200D616AD /* DebugViewController.swift */,
 				3ED5586024C8F15200B97155 /* BluetoothDebugViewController.swift */,
+				3E09C8B324CF662A00D65EF4 /* BluetoothDebugDetailViewController.swift */,
+				3E09C8B524CF6B3700D65EF4 /* BluetoothDebugDetailCell.swift */,
 			);
 			path = Debug;
 			sourceTree = "<group>";
@@ -916,11 +922,13 @@
 				3E82684A249EA6AC00B12FE3 /* SafeTraceProviding.swift in Sources */,
 				DC31D06E24994F7D0039FD6B /* IntroViewController.swift in Sources */,
 				DC31D06F24994F7D0039FD6B /* AppDelegate.swift in Sources */,
+				3E09C8B424CF662A00D65EF4 /* BluetoothDebugDetailViewController.swift in Sources */,
 				DC31D07024994F7D0039FD6B /* WebViewController.swift in Sources */,
 				DC31D07124994F7D0039FD6B /* Fonts.swift in Sources */,
 				DC31D07224994F7D0039FD6B /* TextField.swift in Sources */,
 				3EEFCB54249BCDDC00B74759 /* ContactTracingViewModel.swift in Sources */,
 				3E6A4511249EF627001E94A8 /* Update.swift in Sources */,
+				3E09C8B624CF6B3700D65EF4 /* BluetoothDebugDetailCell.swift in Sources */,
 				3E5A05FC24A139940052A242 /* CitizenUpsellView.swift in Sources */,
 				DCE2DC5224B50D8D0071FE6F /* AnalyticsTracker.swift in Sources */,
 				3EEFCB50249ADAE900B74759 /* ContactTracingViewController.swift in Sources */,


### PR DESCRIPTION
V1 of Bluetooth Debugger that shows you an overview of all the bluetooth peripherals that we've ever encountered while contact tracing, how many of those generate traces and are successfully uploaded. There is also some general metric for average RSSI to the peripheral and average scan interval.

You can also tap into one of the peripherals to see a list of all detections.

Known issues: 
- Android devices are not deduplicated very well since they show up as different peripheral each time. 
- Cannot filter by detections that happened in the background.