### PR TITLE
Gao/cs 315 default to safepass

### DIFF
--- a/safetrace-app/Features/Common/WebViewController.swift
+++ b/safetrace-app/Features/Common/WebViewController.swift
@@ -6,7 +6,21 @@ final class WebViewController: UIViewController {
     private let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
     private let loadingIndicator = UIActivityIndicatorView(style: .whiteLarge)
 
+    private let environment: Environment
+    private let showCloseButton: Bool
+
     var url: URL?
+
+    init(environment: Environment, showCloseButton: Bool) {
+        self.environment = environment
+        self.showCloseButton = showCloseButton
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     /// Load a URL
     func loadUrl(_ url: URL) {
@@ -24,11 +38,26 @@ final class WebViewController: UIViewController {
     private func layoutUI() {
         view.backgroundColor = .stBlack
 
+        navigationController?.setNavigationBarHidden(true, animated: false)
+
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+
+        view.addSubview(stackView)
+
+        // Close Button
+        let closeButtonContainerView = UIView()
         let closeButton = UIButton()
         closeButton.addTarget(self, action: #selector(tapCloseButton), for: .touchUpInside)
         closeButton.setImage(UIImage(named: "closeIcon")!, for: .normal)
         closeButton.accessibilityLabel = NSLocalizedString("Close", comment: "Closes the displayed modal.")
-        view.addSubview(closeButton)
+
+        closeButtonContainerView.addSubview(closeButton)
+        stackView.addArrangedSubview(closeButtonContainerView)
+
+        closeButtonContainerView.isHidden = !showCloseButton
+
+        // WebView
 
         webView.isOpaque = false
         webView.backgroundColor = .stBlack
@@ -38,20 +67,21 @@ final class WebViewController: UIViewController {
         webView.navigationDelegate = self
         webView.uiDelegate = self
 
-        view.addSubview(webView)
+        stackView.addArrangedSubview(webView)
 
         closeButton.translatesAutoresizingMaskIntoConstraints = false
-        webView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             closeButton.widthAnchor.constraint(equalToConstant: 32),
             closeButton.heightAnchor.constraint(equalToConstant: 32),
-            closeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
-            closeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            closeButton.topAnchor.constraint(equalTo: closeButtonContainerView.topAnchor, constant: 12),
+            closeButton.trailingAnchor.constraint(equalTo: closeButtonContainerView.trailingAnchor, constant: -20),
+            closeButton.bottomAnchor.constraint(equalTo: closeButtonContainerView.bottomAnchor, constant: -12),
 
-            webView.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 12),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
 
         view.addSubview(loadingIndicator)

--- a/safetrace-app/Features/Common/WebViewController.swift
+++ b/safetrace-app/Features/Common/WebViewController.swift
@@ -157,6 +157,8 @@ extension WebViewController: WKScriptMessageHandler {
 
                 let javascriptToRun: String = "_tracing.setIsCitizenInstalled(\(isCitizenInstalled))"
                 runJavaScript(javascriptToRun)
+            } else if body == "optInToTracing" {
+                environment.safeTrace.startTracing()
             }
         case "user":
 //            if body == "getLocation" {
@@ -175,6 +177,8 @@ extension WebViewController: WKScriptMessageHandler {
                     .infoDictionary?["CFBundleShortVersionString"] as? String ?? "error"
                 let javascriptToRun = "_user.setAppVersion('\(appVersion)')"
                 runJavaScript(javascriptToRun)
+            } else if body == "goToSettings" {
+                environment.bluetoothPermissions.openSettings()
             }
         case "webView":
             presentWebViewWithURLString(urlString: body)

--- a/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
+++ b/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
@@ -95,8 +95,7 @@ class ContactTracingViewController: UIViewController {
             navigateToAppSettings: navigateToAppSettings,
             openWebView: openWebView,
             openCitizenAppOrAppStore: openCitizenAppOrAppStore,
-            optInSuccessChanged: optInSuccessChanged,
-            redirectToCitizen: redirectToCitizen,
+            transitionToSafePass: transitionToSafePass,
             displayAlert: displayAlert
         ) = contactTracingViewModel(
             environment: environment,
@@ -176,18 +175,12 @@ class ContactTracingViewController: UIViewController {
                 self?.environment.citizen.openSafepass()
             }
 
-        optInSuccessChanged
+        transitionToSafePass
             .take(during: self.reactive.lifetime)
             .observe(on: UIScheduler())
-            .observeValues { [weak self] isSuccess in
-                self?.environment.safeTrace.setLastSuccessfullyOptedIn(isSuccess)
-            }
-
-        redirectToCitizen
-            .take(during: self.reactive.lifetime)
-            .observe(on: UIScheduler())
-            .observeValues { [weak self] in
-                self?.environment.citizen.openSafepass()
+            .observeValues {
+                // TODO
+                print("Opening SafePass")
             }
 
         displayAlert
@@ -225,12 +218,12 @@ class ContactTracingViewController: UIViewController {
             enabledLabel.textColor = .stPurpleAccentUp
             toggle.alpha = 1
         case .error:
-            enabledLabel.textColor = .stRed
-            toggle.alpha = 0.6
+            enabledLabel.textColor = .stPurpleAccentUp
+            toggle.alpha = 1
         }
 
-        bluetoothIconLabelView.showErrorState = viewData.bluetoothDenied
-        notificationIconLabelView.showErrorState = viewData.notificationDenied
+        bluetoothIconLabelView.showErrorState = false
+        notificationIconLabelView.showErrorState = false
 
         getCitizenAppView.titleLabel.text = viewData.isCitizenInstalled
             ? NSLocalizedString("Open Citizen ", comment: "Citizen app upsell title if citizen is installed")

--- a/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
+++ b/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
@@ -179,9 +179,8 @@ class ContactTracingViewController: UIViewController {
         transitionToSafePass
             .take(during: self.reactive.lifetime)
             .observe(on: UIScheduler())
-            .observeValues {
-                // TODO
-                print("Opening SafePass")
+            .observeValues { [weak self] in
+                (self?.navigationController as? MainNavigationController)?.transitionToSafePass()
             }
 
         displayAlert

--- a/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
+++ b/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
@@ -162,10 +162,11 @@ class ContactTracingViewController: UIViewController {
             .take(during: self.reactive.lifetime)
             .observe(on: UIScheduler())
             .observeValues { [weak self] url in
-                let webViewController = WebViewController()
+                guard let self = self else { return }
+                let webViewController = WebViewController(environment: self.environment, showCloseButton: true)
                 webViewController.loadUrl(url)
                 webViewController.modalPresentationStyle = .fullScreen
-                self?.present(webViewController, animated: true)
+                self.present(webViewController, animated: true)
             }
 
         openCitizenAppOrAppStore

--- a/safetrace-app/Features/MainNavigationController.swift
+++ b/safetrace-app/Features/MainNavigationController.swift
@@ -32,13 +32,17 @@ class MainNavigationController: UINavigationController {
                 pushViewController(nextOnboardingController, animated: true)
             }
         } else if environment.safeTrace.getHasOptedInOnce() || environment.safeTrace.isOptedIn {
-            let webViewController = WebViewController(environment: environment, showCloseButton: false)
-            webViewController.loadUrl(environment.safeTrace.safePassURL)
-
-            setViewControllers([webViewController], animated: true)
+            transitionToSafePass()
         } else {
             setViewControllers([ContactTracingViewController(environment: environment)], animated: true)
         }
+    }
+
+    func transitionToSafePass() {
+        let webViewController = WebViewController(environment: environment, showCloseButton: false)
+        webViewController.loadUrl(environment.safeTrace.safePassURL)
+
+        setViewControllers([webViewController], animated: true)
     }
 
 }

--- a/safetrace-app/Features/MainViewController.swift
+++ b/safetrace-app/Features/MainViewController.swift
@@ -31,6 +31,11 @@ class MainNavigationController: UINavigationController {
             } else {
                 pushViewController(nextOnboardingController, animated: true)
             }
+        } else if environment.safeTrace.getHasOptedInOnce() || environment.safeTrace.isOptedIn {
+            let webViewController = WebViewController(environment: environment, showCloseButton: false)
+            webViewController.loadUrl(environment.safeTrace.safePassURL)
+
+            setViewControllers([webViewController], animated: true)
         } else {
             setViewControllers([ContactTracingViewController(environment: environment)], animated: true)
         }

--- a/safetrace-app/Features/Onboarding/Auth Step/EmailVerificationViewController.swift
+++ b/safetrace-app/Features/Onboarding/Auth Step/EmailVerificationViewController.swift
@@ -137,7 +137,7 @@ class EmailVerificationViewController: OnboardingViewController {
     }
 
     @objc private func didTapNeedHelpButton() {
-        let webViewController = WebViewController()
+        let webViewController = WebViewController(environment: environment, showCloseButton: true)
         webViewController.loadUrl(Constants.contactCitizenUrl)
         webViewController.modalPresentationStyle = .fullScreen
         present(webViewController, animated: true)

--- a/safetrace-app/Services/AppEnvironment.swift
+++ b/safetrace-app/Services/AppEnvironment.swift
@@ -8,10 +8,8 @@ struct AppEnvironment: Environment {
     var analytics: AnalyticsTracking = AnalyticsTracker()
 
     init() {
-        if Bundle.main.bundleIdentifier == "org.ctzn.safetrace-dev" {
-            safeTrace.apiEnvironment = .staging
-        } else {
-            safeTrace.apiEnvironment = .production
-        }
+        #if INTERNAL
+        safeTrace.apiEnvironment = .staging
+        #endif
     }
 }

--- a/safetrace-app/Services/AppEnvironment.swift
+++ b/safetrace-app/Services/AppEnvironment.swift
@@ -1,7 +1,17 @@
+import Foundation
+
 struct AppEnvironment: Environment {
     var bluetoothPermissions: BluetoothPermissionsProviding = BluetoothPermissionsProvider()
     var notificationPermissions: NotificationPermissionsProviding = NotificationPermissionsProvider()
     var safeTrace: SafeTraceProviding = SafeTraceProvider()
     var citizen: CitizenProviding = CitizenProvider()
     var analytics: AnalyticsTracking = AnalyticsTracker()
+
+    init() {
+        if Bundle.main.bundleIdentifier == "org.ctzn.safetrace-dev" {
+            safeTrace.apiEnvironment = .staging
+        } else {
+            safeTrace.apiEnvironment = .production
+        }
+    }
 }

--- a/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
@@ -28,7 +28,7 @@ struct SafeTraceProvider: SafeTraceProviding {
         }
     }
 
-    func setHasOptedInOnce() {
+    private func setHasOptedInOnce() {
         UserDefaults.standard.set(true, forKey: "org.ctzn.hasOptedInOnce")
     }
 
@@ -38,6 +38,7 @@ struct SafeTraceProvider: SafeTraceProviding {
 
     func startTracing() {
         SafeTrace.startTracing()
+        setHasOptedInOnce()
     }
 
     func stopTracing() {

--- a/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
@@ -19,6 +19,15 @@ struct SafeTraceProvider: SafeTraceProviding {
         set { SafeTrace.apiEnvironment = newValue }
     }
 
+    var safePassURL: URL {
+        switch SafeTrace.apiEnvironment {
+        case .staging:
+            return URL(string: "https://staging.sp0n.io/tracing/center")!
+        case .production:
+            return URL(string: "https://citizen.com/tracing/center")!
+        }
+    }
+
     func setHasOptedInOnce() {
         UserDefaults.standard.set(true, forKey: "org.ctzn.hasOptedInOnce")
     }

--- a/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
@@ -22,9 +22,9 @@ struct SafeTraceProvider: SafeTraceProviding {
     var safePassURL: URL {
         switch SafeTrace.apiEnvironment {
         case .staging:
-            return URL(string: "https://staging.sp0n.io/tracing/center")!
+            return URL(string: "https://staging.sp0n.io/tracing/safepass")!
         case .production:
-            return URL(string: "https://citizen.com/tracing/center")!
+            return URL(string: "https://citizen.com/tracing/safepass")!
         }
     }
 

--- a/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProvider.swift
@@ -19,12 +19,12 @@ struct SafeTraceProvider: SafeTraceProviding {
         set { SafeTrace.apiEnvironment = newValue }
     }
 
-    func setLastSuccessfullyOptedIn(_ success: Bool) {
-        UserDefaults.standard.set(success, forKey: "org.ctzn.isLastSuccessfullyOptedIn")
+    func setHasOptedInOnce() {
+        UserDefaults.standard.set(true, forKey: "org.ctzn.hasOptedInOnce")
     }
 
-    func getLastSuccessfullyOptedIn() -> Bool {
-        return UserDefaults.standard.bool(forKey: "org.ctzn.isLastSuccessfullyOptedIn")
+    func getHasOptedInOnce() -> Bool {
+        return UserDefaults.standard.bool(forKey: "org.ctzn.hasOptedInOnce")
     }
 
     func startTracing() {

--- a/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
@@ -17,6 +17,6 @@ protocol SafeTraceProviding {
     func applicationWillEnterForeground(_ application: UIApplication)
     func applicationDidEnterBackground(_ application: UIApplication)
 
-    func setLastSuccessfullyOptedIn(_ success: Bool)
-    func getLastSuccessfullyOptedIn() -> Bool
+    func setHasOptedInOnce()
+    func getHasOptedInOnce() -> Bool
 }

--- a/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
@@ -7,6 +7,7 @@ protocol SafeTraceProviding {
     var isTracing: Bool { get }
     var session: SafeTraceSession { get }
     var apiEnvironment: NetworkEnvironment { get set }
+    var safePassURL: URL { get }
 
     func startTracing()
     func stopTracing()

--- a/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
+++ b/safetrace-app/Services/SafeTrace/SafeTraceProviding.swift
@@ -18,6 +18,5 @@ protocol SafeTraceProviding {
     func applicationWillEnterForeground(_ application: UIApplication)
     func applicationDidEnterBackground(_ application: UIApplication)
 
-    func setHasOptedInOnce()
     func getHasOptedInOnce() -> Bool
 }

--- a/safetrace-app/Utility/WebViewHelper.swift
+++ b/safetrace-app/Utility/WebViewHelper.swift
@@ -1,0 +1,24 @@
+import Foundation
+import WebKit
+
+class WebViewHelper {
+    /// List of domains for which we will
+    /// 1. Sync authorized cookies
+    /// 2. Expose javascript messageHandler to
+    private static let authorizedDomains = [
+        "sp0n.io",
+        "citizen.com"
+    ]
+
+    static func isAuthorizedDomain(url: URL) -> Bool {
+        guard let host = url.host else {
+            return false
+        }
+        return authorizedDomains.contains(where: { matchesTopLevelDomain(host: host, domain: $0) })
+    }
+
+    private static func matchesTopLevelDomain(host: String, domain: String) -> Bool {
+        let dottedDomain = "." + domain
+        return host == domain || host.hasSuffix(dottedDomain)
+    }
+}

--- a/safetrace-sdk/Services/Session/UserSession.swift
+++ b/safetrace-sdk/Services/Session/UserSession.swift
@@ -83,7 +83,7 @@ class UserSession: UserSessionProtocol {
 
         setFirstTimeDefaultIfNeeded()
         attemptToLoadCachedValues()
-        
+
         if !isAuthenticated {
             attemptToLoadValuesFromAppGroup(groupKeychain: groupKeychain)
         }

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -1148,7 +1148,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -1180,7 +1180,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -1251,7 +1251,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ctzn.safetrace;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTrace;
@@ -1276,7 +1276,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ctzn.safetrace;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTrace;
@@ -1300,7 +1300,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-dev";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTraceDev;
@@ -1325,7 +1325,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-dev";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTraceDev;
@@ -1350,7 +1350,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-dev";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTraceDev;
@@ -1437,7 +1437,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -1486,7 +1486,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ctzn.safetrace;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTrace;

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -74,7 +74,7 @@
 		DC0D959324B4E6D5003E38E0 /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = DC0D959224B4E6D5003E38E0 /* Analytics */; };
 		DC0E0F982498261700D3C9FC /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F972498261700D3C9FC /* BackButton.swift */; };
 		DC0E0F9A2498263E00D3C9FC /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F992498263E00D3C9FC /* WebViewController.swift */; };
-		DC0E0F9C2498267800D3C9FC /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F9B2498267800D3C9FC /* MainViewController.swift */; };
+		DC0E0F9C2498267800D3C9FC /* MainNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F9B2498267800D3C9FC /* MainNavigationController.swift */; };
 		DC0E0FA1249826CD00D3C9FC /* BluetoothPermissionsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0FA0249826CD00D3C9FC /* BluetoothPermissionsProviding.swift */; };
 		DC0E0FA72498271F00D3C9FC /* OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0FA62498271F00D3C9FC /* OnboardingStep.swift */; };
 		DC0E0FA92498273700D3C9FC /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0FA82498273700D3C9FC /* OnboardingViewController.swift */; };
@@ -90,7 +90,7 @@
 		DC31D07424994F7D0039FD6B /* PhoneVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */; };
 		DC31D07524994F7D0039FD6B /* BluetoothPermissionsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0FA0249826CD00D3C9FC /* BluetoothPermissionsProviding.swift */; };
 		DC31D07624994F7D0039FD6B /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A23244C0886006520E4 /* Button.swift */; };
-		DC31D07724994F7D0039FD6B /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F9B2498267800D3C9FC /* MainViewController.swift */; };
+		DC31D07724994F7D0039FD6B /* MainNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0E0F9B2498267800D3C9FC /* MainNavigationController.swift */; };
 		DC31D07824994F7D0039FD6B /* TappableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5F6380244FDCF900C508A4 /* TappableTextView.swift */; };
 		DC31D07924994F7D0039FD6B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5F6382245209D900C508A4 /* Constants.swift */; };
 		DC31D07B24994F7D0039FD6B /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A27244C1959006520E4 /* UIView+.swift */; };
@@ -241,7 +241,7 @@
 		DC0D959524B4F1E7003E38E0 /* AnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		DC0E0F972498261700D3C9FC /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		DC0E0F992498263E00D3C9FC /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
-		DC0E0F9B2498267800D3C9FC /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		DC0E0F9B2498267800D3C9FC /* MainNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavigationController.swift; sourceTree = "<group>"; };
 		DC0E0FA0249826CD00D3C9FC /* BluetoothPermissionsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPermissionsProviding.swift; sourceTree = "<group>"; };
 		DC0E0FA62498271F00D3C9FC /* OnboardingStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStep.swift; sourceTree = "<group>"; };
 		DC0E0FA82498273700D3C9FC /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
@@ -601,7 +601,7 @@
 				3E82684F249EB2A400B12FE3 /* Common */,
 				3E82684E249EB23C00B12FE3 /* Contact Tracing */,
 				DC0E0F9D249826B500D3C9FC /* Onboarding */,
-				DC0E0F9B2498267800D3C9FC /* MainViewController.swift */,
+				DC0E0F9B2498267800D3C9FC /* MainNavigationController.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -895,7 +895,7 @@
 				3E826849249EA6AC00B12FE3 /* SafeTraceProviding.swift in Sources */,
 				DC0E0FA1249826CD00D3C9FC /* BluetoothPermissionsProviding.swift in Sources */,
 				3E0E3A24244C0886006520E4 /* Button.swift in Sources */,
-				DC0E0F9C2498267800D3C9FC /* MainViewController.swift in Sources */,
+				DC0E0F9C2498267800D3C9FC /* MainNavigationController.swift in Sources */,
 				3EB4386C249D4A4200AA80DF /* Reactive+.swift in Sources */,
 				3E5F6381244FDCF900C508A4 /* TappableTextView.swift in Sources */,
 				3E5F6383245209D900C508A4 /* Constants.swift in Sources */,
@@ -944,7 +944,7 @@
 				3E5A05F524A1194E0052A242 /* SeparatorView.swift in Sources */,
 				DC31D07624994F7D0039FD6B /* Button.swift in Sources */,
 				3EB4386D249D4A4200AA80DF /* Reactive+.swift in Sources */,
-				DC31D07724994F7D0039FD6B /* MainViewController.swift in Sources */,
+				DC31D07724994F7D0039FD6B /* MainNavigationController.swift in Sources */,
 				3E6A450A249ECD93001E94A8 /* PermissionImageLabelView.swift in Sources */,
 				DC31D07824994F7D0039FD6B /* TappableTextView.swift in Sources */,
 				3E826842249E9D8100B12FE3 /* Environment.swift in Sources */,

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		3EB4386D249D4A4200AA80DF /* Reactive+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB4386B249D4A4200AA80DF /* Reactive+.swift */; };
 		3EBA763124C64DC4005F3597 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */; };
 		3EBA763224C64DC4005F3597 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */; };
+		3EC7599F24F5C87F00B42D81 /* WebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */; };
+		3EC759A024F5C87F00B42D81 /* WebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */; };
 		3EE970BF244CBB2000AAF2CF /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970BE244CBB2000AAF2CF /* TextField.swift */; };
 		3EE970CB244CEAA800AAF2CF /* PhoneVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */; };
 		3EEFCB4D249AC5B800B74759 /* ContactTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */; };
@@ -217,6 +219,7 @@
 		3EB43868249D125500AA80DF /* NotificationPermissionsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionsProviding.swift; sourceTree = "<group>"; };
 		3EB4386B249D4A4200AA80DF /* Reactive+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reactive+.swift"; sourceTree = "<group>"; };
 		3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvents.swift; sourceTree = "<group>"; };
+		3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewHelper.swift; sourceTree = "<group>"; };
 		3EE970BE244CBB2000AAF2CF /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 		3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerificationViewController.swift; sourceTree = "<group>"; };
 		3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTracingViewController.swift; sourceTree = "<group>"; };
@@ -383,6 +386,7 @@
 			isa = PBXGroup;
 			children = (
 				3E6A450F249EF627001E94A8 /* Update.swift */,
+				3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -898,6 +902,7 @@
 				DC0E0F9C2498267800D3C9FC /* MainNavigationController.swift in Sources */,
 				3EB4386C249D4A4200AA80DF /* Reactive+.swift in Sources */,
 				3E5F6381244FDCF900C508A4 /* TappableTextView.swift in Sources */,
+				3EC7599F24F5C87F00B42D81 /* WebViewHelper.swift in Sources */,
 				3E5F6383245209D900C508A4 /* Constants.swift in Sources */,
 				3E826844249EA00E00B12FE3 /* AppEnvironment.swift in Sources */,
 				3E5A05F124A02F1B0052A242 /* OnboardingTextField.swift in Sources */,
@@ -960,6 +965,7 @@
 				DC31D07F24994F7D0039FD6B /* PhoneEnterViewController.swift in Sources */,
 				DC8DF29724CF7F1E00077C24 /* AppSwitcherOverlayViewController.swift in Sources */,
 				3E5A05E9249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */,
+				3EC759A024F5C87F00B42D81 /* WebViewHelper.swift in Sources */,
 				3E5A060324A143AB0052A242 /* CitizenProviding.swift in Sources */,
 				3EBA763224C64DC4005F3597 /* AnalyticsEvents.swift in Sources */,
 				DCB94CCC249BC43D00D616AD /* DebugViewController.swift in Sources */,

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -1148,7 +1148,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -1180,7 +1180,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -1251,7 +1251,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ctzn.safetrace;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTrace;
@@ -1276,7 +1276,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ctzn.safetrace;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTrace;
@@ -1300,7 +1300,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-dev";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTraceDev;
@@ -1325,7 +1325,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-dev";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTraceDev;
@@ -1350,7 +1350,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-dev";
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTraceDev;
@@ -1437,7 +1437,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -1486,7 +1486,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ctzn.safetrace;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = SafeTrace;


### PR DESCRIPTION
## Changes:

- After permissions have been asked, route to safepass regardless of permission errors
- As long as the user has opted in before, always route to safepass when cold launching app. The SafePass will have all the surfaces for opting out, as well as fixing error states.
- Point dev builds to staging by default
- Added javascript interface to the existing `WebViewController`, and added ability to hide its close button
- Bump version number to v1.5.0