### PR TITLE
Gao/cs 334 log out when reinstall

### DIFF
--- a/safetrace-sdk/Services/Session/UserSession.swift
+++ b/safetrace-sdk/Services/Session/UserSession.swift
@@ -90,6 +90,8 @@ class UserSession: UserSessionProtocol {
     }
 
     func logout() {
+        SafeTrace.stopTracing()
+
         updateStoredValues(token: nil, userID: nil)
         authenticationDelegate?.authenticationStatusDidChange(forSession: self)
     }

--- a/safetrace-sdk/Services/Session/UserSession.swift
+++ b/safetrace-sdk/Services/Session/UserSession.swift
@@ -254,8 +254,7 @@ class UserSession: UserSessionProtocol {
         guard !UserDefaults.standard.bool(forKey: "org.ctzn.firstInstall") else { return }
 
         UserDefaults.standard.set(true, forKey: "org.ctzn.firstInstall")
-        // We need to revisit this when 1.0 users are at a negligible amount
-//        logout()
+        logout()
     }
 }
 

--- a/safetrace-sdk/Services/TracerEnvironment.swift
+++ b/safetrace-sdk/Services/TracerEnvironment.swift
@@ -19,7 +19,6 @@ class TracerEnvironment: Environment {
 extension TracerEnvironment: UserSessionAuthenticationDelegate {
     func authenticationStatusDidChange(forSession: UserSessionProtocol) {
         if !session.isAuthenticated {
-            SafeTrace.stopTracing()
             traceIDs.clear()
         }
     }

--- a/safetrace-sdk/Services/TracerEnvironment.swift
+++ b/safetrace-sdk/Services/TracerEnvironment.swift
@@ -19,7 +19,7 @@ class TracerEnvironment: Environment {
 extension TracerEnvironment: UserSessionAuthenticationDelegate {
     func authenticationStatusDidChange(forSession: UserSessionProtocol) {
         if !session.isAuthenticated {
-            tracer.optOut()
+            SafeTrace.stopTracing()
             traceIDs.clear()
         }
     }


### PR DESCRIPTION
Log the user out when reinstalling. Also, call `SafeTrace.stopTracing()` before performing the opt out, so that the server may be notified of this opt-out.