### PR TITLE
Send a health check right before opening safepass for the first time,

### DIFF
--- a/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
+++ b/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
@@ -170,6 +170,7 @@ class ContactTracingViewController: UIViewController {
             .take(during: self.reactive.lifetime)
             .observe(on: UIScheduler())
             .observeValues { [weak self] in
+                SafeTrace.sendHealthCheck(wakeReason: .permissionsAsked)
                 (self?.navigationController as? MainNavigationController)?.transitionToSafePass()
             }
 

--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -7,6 +7,7 @@ public enum WakeReason: String, Encodable {
     case appForeground = "app_foreground"
     case appBackground = "app_background"
     case bluetooth = "bluetooth"
+    case permissionsAsked = "permissions_asked"
 }
 
 public final class SafeTrace {


### PR DESCRIPTION
Send a health check right before opening safepass for the first time, so SafePass knows about the updated permissions when you first open it