### PR TITLE
Location Permissions and location sync with background

### DIFF
--- a/safetrace-app/Extensions/CLLocationCoordinate+.swift
+++ b/safetrace-app/Extensions/CLLocationCoordinate+.swift
@@ -1,0 +1,32 @@
+import CoreLocation
+import Foundation
+
+extension CLLocationCoordinate2D {
+    func withDecimalPrecision(_ places: Int) -> CLLocationCoordinate2D {
+        return CLLocationCoordinate2D(
+            latitude: latitude.roundTo(places: places),
+            longitude: longitude.roundTo(places: places)
+        )
+    }
+}
+
+private extension Double {
+    /// Rounds the double to decimal places value
+    func roundTo(places: Int) -> Double {
+        let divisor = pow(10.0, Double(places))
+        return (self * divisor).rounded() / divisor
+    }
+}
+
+extension CLLocation {
+    func withDecimalPrecision(_ places: Int) -> CLLocation {
+        return CLLocation(
+            coordinate: coordinate.withDecimalPrecision(places),
+            altitude: altitude,
+            horizontalAccuracy: horizontalAccuracy,
+            verticalAccuracy: verticalAccuracy,
+            course: course,
+            speed: speed,
+            timestamp: timestamp)
+    }
+}

--- a/safetrace-app/Features/Common/WebViewController.swift
+++ b/safetrace-app/Features/Common/WebViewController.swift
@@ -185,17 +185,15 @@ extension WebViewController: WKScriptMessageHandler {
                 environment.safeTrace.startTracing()
             }
         case "user":
-//            if body == "getLocation" {
-//                let javascriptToRun: String
-//                if let currentLocation = environment.location.current {
-//                    javascriptToRun = "_user.setLocation({'lat': \(currentLocation.coordinate.latitude), 'long': \(currentLocation.coordinate.longitude)})"
-//                } else {
-//                    javascriptToRun = "_user.setLocation(null)"
-//                }
-//                runJavaScript(javascriptToRun)
-//            } else
-
-            if body == "getAppVersion" {
+            if body == "getLocation" {
+                let javascriptToRun: String
+                if let currentLocation = environment.location.currentLocation {
+                    javascriptToRun = "_user.setLocation({'lat': \(currentLocation.coordinate.latitude), 'long': \(currentLocation.coordinate.longitude)})"
+                } else {
+                    javascriptToRun = "_user.setLocation(null)"
+                }
+                runJavaScript(javascriptToRun)
+            } else if body == "getAppVersion" {
                 let appVersion = Bundle
                     .main
                     .infoDictionary?["CFBundleShortVersionString"] as? String ?? "error"

--- a/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
+++ b/safetrace-app/Features/Contact Tracing/ContactTracingViewController.swift
@@ -92,6 +92,7 @@ class ContactTracingViewController: UIViewController {
             optOut: optOut,
             askBluetoothPermissions: askBluetoothPermissions,
             askNotificationPermissions: askNotificationPermissions,
+            askLocationPermissions: askLocationPermissions,
             navigateToAppSettings: navigateToAppSettings,
             openWebView: openWebView,
             finishedAskingPermissions: finishedAskingPermissions,
@@ -147,6 +148,13 @@ class ContactTracingViewController: UIViewController {
                 self?.environment.notificationPermissions.requestPushNotifications { [weak self] success in
                     self?.notificationPermissionsChangedPipe.input.send(value: success ? .authorized : .denied)
                 }
+            }
+
+        askLocationPermissions
+            .take(during: self.reactive.lifetime)
+            .observe(on: UIScheduler())
+            .observeValues { [weak self] in
+                self?.environment.location.requestAlwaysLocationPermissions()
             }
 
         navigateToAppSettings

--- a/safetrace-app/Info.plist
+++ b/safetrace-app/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>SafePass uses your location to tell you where you were exposed to COVID-19.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>SafePass uses your location to tell you where you were exposed to COVID-19.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -43,6 +47,7 @@
 	<string>SafeTrace uses Bluetooth to determine if you have come in nearby contact with someone who has tested positive for COVID-19.</string>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>location</string>
 		<string>bluetooth-peripheral</string>
 		<string>bluetooth-central</string>
 		<string>fetch</string>

--- a/safetrace-app/Services/AppEnvironment.swift
+++ b/safetrace-app/Services/AppEnvironment.swift
@@ -3,6 +3,7 @@ import Foundation
 struct AppEnvironment: Environment {
     var bluetoothPermissions: BluetoothPermissionsProviding = BluetoothPermissionsProvider()
     var notificationPermissions: NotificationPermissionsProviding = NotificationPermissionsProvider()
+    var location: LocationProviding = LocationProvider()
     var safeTrace: SafeTraceProviding = SafeTraceProvider()
     var citizen: CitizenProviding = CitizenProvider()
     var analytics: AnalyticsTracking = AnalyticsTracker()

--- a/safetrace-app/Services/Environment.swift
+++ b/safetrace-app/Services/Environment.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol Environment {
     var bluetoothPermissions: BluetoothPermissionsProviding { get }
     var notificationPermissions: NotificationPermissionsProviding { get }
+    var location: LocationProviding { get }
     var analytics: AnalyticsTracking { get }
     var safeTrace: SafeTraceProviding { get }
     var citizen: CitizenProviding { get }

--- a/safetrace-app/Services/Permissions/LocationProviding.swift
+++ b/safetrace-app/Services/Permissions/LocationProviding.swift
@@ -1,0 +1,72 @@
+import CoreLocation
+import Foundation
+import ReactiveSwift
+
+protocol ReactiveLocationProtocol {
+    var current: SignalProducer<CLLocation?, Never> { get }
+    var authorizationStatus: SignalProducer<CLAuthorizationStatus, Never> { get }
+}
+
+protocol LocationProviding {
+    var reactive: ReactiveLocationProtocol { get }
+    var currentLocation: CLLocation? { get }
+    var currentAuthorization: CLAuthorizationStatus { get }
+    func requestAlwaysLocationPermissions()
+}
+
+class ReactiveLocation: ReactiveLocationProtocol {
+    var current: SignalProducer<CLLocation?, Never>
+    var authorizationStatus: SignalProducer<CLAuthorizationStatus, Never>
+
+    fileprivate let _location = MutableProperty<CLLocation?>(nil)
+    fileprivate let _authorizationStatus = MutableProperty<CLAuthorizationStatus>(.notDetermined)
+
+    init() {
+        current = _location.producer
+        authorizationStatus = _authorizationStatus.producer
+    }
+}
+
+class LocationProvider: NSObject, LocationProviding {
+
+    fileprivate let _reactive = ReactiveLocation()
+    fileprivate let locationManager = CLLocationManager()
+    fileprivate let decimalPrecision = 5
+
+
+    var reactive: ReactiveLocationProtocol {
+        return _reactive
+    }
+
+    var currentLocation: CLLocation? {
+        _reactive._location.value
+    }
+
+    var currentAuthorization: CLAuthorizationStatus {
+        _reactive._authorizationStatus.value
+    }
+
+    override init() {
+        super.init()
+
+        locationManager.delegate = self
+        _reactive._authorizationStatus.value = CLLocationManager.authorizationStatus()
+    }
+
+    func requestAlwaysLocationPermissions() {
+        locationManager.requestAlwaysAuthorization()
+    }
+
+}
+
+extension LocationProvider: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        _reactive._authorizationStatus.value = status
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+
+        _reactive._location.value = location
+    }
+}

--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -173,6 +173,16 @@ public final class SafeTrace {
             sendCheck()
         }
     }
+
+    public static func syncLocation(_ location: LocationRequest, completion: (() -> Void)? = nil) {
+        guard let userID = environment.session.userID else { return }
+        let task = UIApplication.shared.beginBackgroundTask()
+
+        environment.network.syncLocation(location, userID: userID) { _ in
+            completion?()
+            UIApplication.shared.endBackgroundTask(task)
+        }
+    }
 }
 
 extension SafeTrace {

--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import UIKit
 
 public enum WakeReason: String, Encodable {
@@ -61,6 +62,9 @@ public final class SafeTrace {
         let isOptedIn = environment.tracer.isTracingEnabled
         let appVersion = UIApplication.clientApplicationVersionShortDescription
         let bluetoothHardwareEnabled = environment.tracer.isBluetoothHardwareEnabled
+        let locationAuthorization = CLLocationManager.authorizationStatus()
+        let locationEnabled = locationAuthorization == .authorizedAlways
+            || locationAuthorization == .authorizedWhenInUse
         UIDevice.current.isBatteryMonitoringEnabled = true
         let batteryLevel = Int(UIDevice.current.batteryLevel * 100)
         let isLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
@@ -74,6 +78,7 @@ public final class SafeTrace {
                 userID: userID,
                 bluetoothEnabled: bluetoothEnabled,
                 notificationsEnabled: pushEnabled,
+                locationEnabled: locationEnabled,
                 wakeReason: wakeReason,
                 isOptedIn: isOptedIn,
                 appVersion: appVersion,

--- a/safetrace-sdk/Services/Networking/Models/LocationRequest.swift
+++ b/safetrace-sdk/Services/Networking/Models/LocationRequest.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct LocationRequest: Codable {
+    public let latitude: Double
+    public let longitude: Double
+    public let horizontalAccuracy: Double
+    public let verticalAccuracy: Double
+    public let elevation: Double
+    public let speed: Double
+    public let bearing: Double
+    public let background: Bool
+    
+    public init(
+        lat: Double,
+        long: Double,
+        hAccuracy: Double,
+        vAccuracy: Double,
+        elevation: Double,
+        speed: Double,
+        bearing: Double,
+        background: Bool
+    ) {
+        self.latitude = lat
+        self.longitude = long
+        self.horizontalAccuracy = hAccuracy
+        self.verticalAccuracy = vAccuracy
+        self.elevation = elevation
+        self.speed = speed
+        self.bearing = bearing
+        self.background = background
+    }
+}

--- a/safetrace-sdk/Services/Networking/Networking.swift
+++ b/safetrace-sdk/Services/Networking/Networking.swift
@@ -16,6 +16,7 @@ protocol NetworkProtocol {
         userID: String,
         bluetoothEnabled: Bool,
         notificationsEnabled: Bool,
+        locationEnabled: Bool,
         wakeReason: WakeReason,
         isOptedIn: Bool,
         appVersion: String,
@@ -162,6 +163,7 @@ class Network: NetworkProtocol {
         userID: String,
         bluetoothEnabled: Bool,
         notificationsEnabled: Bool,
+        locationEnabled: Bool,
         wakeReason: WakeReason,
         isOptedIn: Bool,
         appVersion: String,
@@ -173,6 +175,7 @@ class Network: NetworkProtocol {
         struct HealthCheckPayload: Encodable {
             let bluetooth_enabled: Bool
             let notifications_enabled: Bool
+            let location_enabled: Bool
             let wake_reason: WakeReason
             let is_opted_in: Bool
             let app_version: String
@@ -189,6 +192,7 @@ class Network: NetworkProtocol {
                 body: HealthCheckPayload(
                     bluetooth_enabled: bluetoothEnabled,
                     notifications_enabled: notificationsEnabled,
+                    location_enabled: locationEnabled,
                     wake_reason: wakeReason,
                     is_opted_in: isOptedIn,
                     app_version: appVersion,

--- a/safetrace-sdk/Services/Networking/Networking.swift
+++ b/safetrace-sdk/Services/Networking/Networking.swift
@@ -27,6 +27,8 @@ protocol NetworkProtocol {
 
     func getTraceIDs(userID: String, completion: @escaping (Result<[TraceIDRecord], Error>) -> Void)
     func uploadTraces(_ traces: ContactTraces, userID: String, completion: @escaping (Result<Void, Error>) -> Void)
+
+    func syncLocation(_ location: LocationRequest, userID: String, completion: @escaping (Result<Void, Error>) -> Void)
     
 }
 
@@ -220,5 +222,20 @@ class Network: NetworkProtocol {
                 body: traces,
                 dateEncodingStrategy: .iso8601),
             completion:completion)
+    }
+
+    // MARK: - Location
+
+    func syncLocation(_ location: LocationRequest, userID: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        urlSession.sendRequest(
+            with: try URLRequest(
+                endpoint: "v1/users/\(userID)/location",
+                method: .post,
+                host: .sp0n,
+                token: environment.session.authToken,
+                body: location
+            ),
+            completion: completion
+        )
     }
 }

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -44,12 +44,12 @@
 		3EB4386D249D4A4200AA80DF /* Reactive+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB4386B249D4A4200AA80DF /* Reactive+.swift */; };
 		3EBA763124C64DC4005F3597 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */; };
 		3EBA763224C64DC4005F3597 /* AnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */; };
+		3EC759A224F6BA5500B42D81 /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A124F6BA5500B42D81 /* LocationProviding.swift */; };
+		3EC759A324F6BA5500B42D81 /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A124F6BA5500B42D81 /* LocationProviding.swift */; };
 		3EC759A524F87CAD00B42D81 /* WebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */; };
 		3EC759A624F87CAD00B42D81 /* WebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */; };
 		3EC759A824F8818A00B42D81 /* WebErrorRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */; };
 		3EC759A924F8818A00B42D81 /* WebErrorRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */; };
-		3EC759A224F6BA5500B42D81 /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A124F6BA5500B42D81 /* LocationProviding.swift */; };
-		3EC759A324F6BA5500B42D81 /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A124F6BA5500B42D81 /* LocationProviding.swift */; };
 		3EE970BF244CBB2000AAF2CF /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970BE244CBB2000AAF2CF /* TextField.swift */; };
 		3EE970CB244CEAA800AAF2CF /* PhoneVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */; };
 		3EEFCB4D249AC5B800B74759 /* ContactTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */; };
@@ -221,8 +221,8 @@
 		3EB4386B249D4A4200AA80DF /* Reactive+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reactive+.swift"; sourceTree = "<group>"; };
 		3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvents.swift; sourceTree = "<group>"; };
 		3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewHelper.swift; sourceTree = "<group>"; };
-		3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebErrorRetryView.swift; sourceTree = "<group>"; };
 		3EC759A124F6BA5500B42D81 /* LocationProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProviding.swift; sourceTree = "<group>"; };
+		3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebErrorRetryView.swift; sourceTree = "<group>"; };
 		3EE970BE244CBB2000AAF2CF /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 		3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerificationViewController.swift; sourceTree = "<group>"; };
 		3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTracingViewController.swift; sourceTree = "<group>"; };
@@ -253,7 +253,6 @@
 		DC0E0FA82498273700D3C9FC /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		DC0E0FAA2498274B00D3C9FC /* AuthOnboardingStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthOnboardingStep.swift; sourceTree = "<group>"; };
 		DC31D08B24994F7D0039FD6B /* SafePassDev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SafePassDev.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		DC31D08C24994F7E0039FD6B /* safetrace-app-dev-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "safetrace-app-dev-Info.plist"; path = "/Users/maxmamis/code/safetrace-ios/safetrace-app-dev-Info.plist"; sourceTree = "<absolute>"; };
 		DC31D08D24994FB10039FD6B /* safetrace-app-dev.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "safetrace-app-dev.entitlements"; sourceTree = "<group>"; };
 		DC738ACA247F02CA000BF99E /* LocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProvider.swift; sourceTree = "<group>"; };
 		DC7AC09824475486000FF13D /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
@@ -519,7 +518,6 @@
 				DC0BBB4624469C9C00B18911 /* Assets.xcassets */,
 				DC0BBB4824469C9C00B18911 /* LaunchScreen.storyboard */,
 				DC0BBB4B24469C9C00B18911 /* Info.plist */,
-				DC31D08C24994F7E0039FD6B /* safetrace-app-dev-Info.plist */,
 			);
 			path = "safetrace-app";
 			sourceTree = "<group>";
@@ -1300,7 +1298,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L5262XM8UA;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				INFOPLIST_FILE = "safetrace-app-dev-Info.plist";
+				INFOPLIST_FILE = "safetrace-app/info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1325,7 +1323,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L5262XM8UA;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				INFOPLIST_FILE = "safetrace-app-dev-Info.plist";
+				INFOPLIST_FILE = "safetrace-app/info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1350,7 +1348,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L5262XM8UA;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				INFOPLIST_FILE = "safetrace-app-dev-Info.plist";
+				INFOPLIST_FILE = "safetrace-app/info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		3E0E3A28244C1959006520E4 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0E3A27244C1959006520E4 /* UIView+.swift */; };
 		3E32BDB524F970A600F5A2A8 /* SLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E32BDB424F970A600F5A2A8 /* SLog.swift */; };
 		3E32BDB624F970A600F5A2A8 /* SLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E32BDB424F970A600F5A2A8 /* SLog.swift */; };
+		3E32BDB924F9BAC400F5A2A8 /* LocationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E32BDB824F9BAC400F5A2A8 /* LocationRequest.swift */; };
+		3E32BDBB24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E32BDBA24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift */; };
+		3E32BDBC24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E32BDBA24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift */; };
 		3E5A05E8249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */; };
 		3E5A05E9249FDFC80052A242 /* EmailVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */; };
 		3E5A05F124A02F1B0052A242 /* OnboardingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A05F024A02F1B0052A242 /* OnboardingTextField.swift */; };
@@ -204,6 +207,8 @@
 		3E0E3A23244C0886006520E4 /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		3E0E3A27244C1959006520E4 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		3E32BDB424F970A600F5A2A8 /* SLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SLog.swift; sourceTree = "<group>"; };
+		3E32BDB824F9BAC400F5A2A8 /* LocationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRequest.swift; sourceTree = "<group>"; };
+		3E32BDBA24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate+.swift"; sourceTree = "<group>"; };
 		3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationViewController.swift; sourceTree = "<group>"; };
 		3E5A05F024A02F1B0052A242 /* OnboardingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTextField.swift; sourceTree = "<group>"; };
 		3E5A05F324A1194E0052A242 /* SeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorView.swift; sourceTree = "<group>"; };
@@ -335,6 +340,7 @@
 				3EEFCB4E249AC93700B74759 /* UIScreen+.swift */,
 				3EEFCB64249BFD1100B74759 /* UIViewController+.swift */,
 				3EB4386B249D4A4200AA80DF /* Reactive+.swift */,
+				3E32BDBA24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -362,6 +368,14 @@
 				3E5A05E7249FDFC80052A242 /* EmailVerificationViewController.swift */,
 			);
 			path = "Auth Step";
+			sourceTree = "<group>";
+		};
+		3E32BDB724F9BA9000F5A2A8 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3E32BDB824F9BAC400F5A2A8 /* LocationRequest.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		3E5A05F624A135370052A242 /* Views */ = {
@@ -556,6 +570,7 @@
 			children = (
 				DC7AC09824475486000FF13D /* Networking.swift */,
 				DC7AC09B24478B3A000FF13D /* URLSession+.swift */,
+				3E32BDB724F9BA9000F5A2A8 /* Models */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -847,6 +862,7 @@
 				DC7AC09F24478DF8000FF13D /* Environment.swift in Sources */,
 				DC0BBB2D24468EA500B18911 /* SafeTrace.swift in Sources */,
 				DC0BBB302446957000B18911 /* ContactTracer.swift in Sources */,
+				3E32BDB924F9BAC400F5A2A8 /* LocationRequest.swift in Sources */,
 				DC7F32FA244A180D009B61B8 /* BluetoothCentral.swift in Sources */,
 				DC7F32F4244933DA009B61B8 /* BluetoothPeripheral.swift in Sources */,
 				DC7AC0A524479495000FF13D /* UserSession.swift in Sources */,
@@ -900,6 +916,7 @@
 				DC0E0FA1249826CD00D3C9FC /* BluetoothPermissionsProviding.swift in Sources */,
 				3E0E3A24244C0886006520E4 /* Button.swift in Sources */,
 				DC0E0F9C2498267800D3C9FC /* MainNavigationController.swift in Sources */,
+				3E32BDBB24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift in Sources */,
 				3EB4386C249D4A4200AA80DF /* Reactive+.swift in Sources */,
 				3E5F6381244FDCF900C508A4 /* TappableTextView.swift in Sources */,
 				3E5F6383245209D900C508A4 /* Constants.swift in Sources */,
@@ -937,6 +954,7 @@
 				DC31D06F24994F7D0039FD6B /* AppDelegate.swift in Sources */,
 				DC31D07024994F7D0039FD6B /* WebViewController.swift in Sources */,
 				DC31D07124994F7D0039FD6B /* Fonts.swift in Sources */,
+				3E32BDBC24F9BE4600F5A2A8 /* CLLocationCoordinate+.swift in Sources */,
 				DC31D07224994F7D0039FD6B /* TextField.swift in Sources */,
 				3EEFCB54249BCDDC00B74759 /* ContactTracingViewModel.swift in Sources */,
 				3E6A4511249EF627001E94A8 /* Update.swift in Sources */,

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		3EC759A624F87CAD00B42D81 /* WebViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */; };
 		3EC759A824F8818A00B42D81 /* WebErrorRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */; };
 		3EC759A924F8818A00B42D81 /* WebErrorRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */; };
+		3EC759A224F6BA5500B42D81 /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A124F6BA5500B42D81 /* LocationProviding.swift */; };
+		3EC759A324F6BA5500B42D81 /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC759A124F6BA5500B42D81 /* LocationProviding.swift */; };
 		3EE970BF244CBB2000AAF2CF /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970BE244CBB2000AAF2CF /* TextField.swift */; };
 		3EE970CB244CEAA800AAF2CF /* PhoneVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */; };
 		3EEFCB4D249AC5B800B74759 /* ContactTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */; };
@@ -220,6 +222,7 @@
 		3EBA763024C64DC4005F3597 /* AnalyticsEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvents.swift; sourceTree = "<group>"; };
 		3EC7599E24F5C87F00B42D81 /* WebViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewHelper.swift; sourceTree = "<group>"; };
 		3EC759A724F8818A00B42D81 /* WebErrorRetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebErrorRetryView.swift; sourceTree = "<group>"; };
+		3EC759A124F6BA5500B42D81 /* LocationProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProviding.swift; sourceTree = "<group>"; };
 		3EE970BE244CBB2000AAF2CF /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 		3EE970CA244CEAA800AAF2CF /* PhoneVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerificationViewController.swift; sourceTree = "<group>"; };
 		3EEFCB4C249AC5B800B74759 /* ContactTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTracingViewController.swift; sourceTree = "<group>"; };
@@ -407,6 +410,7 @@
 			isa = PBXGroup;
 			children = (
 				DC0E0FA0249826CD00D3C9FC /* BluetoothPermissionsProviding.swift */,
+				3EC759A124F6BA5500B42D81 /* LocationProviding.swift */,
 				3EB43868249D125500AA80DF /* NotificationPermissionsProviding.swift */,
 			);
 			path = Permissions;
@@ -917,6 +921,7 @@
 				3E32BDB524F970A600F5A2A8 /* SLog.swift in Sources */,
 				3EEFCB4D249AC5B800B74759 /* ContactTracingViewController.swift in Sources */,
 				DCE2DC5124B50D8D0071FE6F /* AnalyticsTracker.swift in Sources */,
+				3EC759A224F6BA5500B42D81 /* LocationProviding.swift in Sources */,
 				3E82684C249EA6C200B12FE3 /* SafeTraceProvider.swift in Sources */,
 				3EC759A524F87CAD00B42D81 /* WebViewHelper.swift in Sources */,
 			);
@@ -937,6 +942,7 @@
 				DC31D07224994F7D0039FD6B /* TextField.swift in Sources */,
 				3EEFCB54249BCDDC00B74759 /* ContactTracingViewModel.swift in Sources */,
 				3E6A4511249EF627001E94A8 /* Update.swift in Sources */,
+				3EC759A324F6BA5500B42D81 /* LocationProviding.swift in Sources */,
 				DCE2DC5224B50D8D0071FE6F /* AnalyticsTracker.swift in Sources */,
 				3EEFCB50249ADAE900B74759 /* ContactTracingViewController.swift in Sources */,
 				3E32BDB624F970A600F5A2A8 /* SLog.swift in Sources */,


### PR DESCRIPTION
- Added logic for asking for location permissions when tapping toggle
- If location is granted, sync location with server whenever it becomes available
- Allow background syncing of location
- Send new `location_enabled` field to health checks. `true` means location permissions are either granted for `.authorizedAlways` or `.authorizedWhenInUse`
- Javascript interface for getting location is now functional