### PR TITLE
Ability to upload location to server

### DIFF
--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -32,6 +32,8 @@ public final class SafeTrace {
     }
 
     public static var applicationUserAgent: String?
+
+    public static var tracingStatusChangeHandler: ((Bool) -> Void)?
     
     /// Will start the scanning process. May only be called once authenticated.
     public static func startTracing() {
@@ -44,6 +46,7 @@ public final class SafeTrace {
             true,
             userID: userID,
             completion: { _ in })
+        SafeTrace.tracingStatusChangeHandler?(true)
     }
 
     public static func stopTracing() {
@@ -55,6 +58,7 @@ public final class SafeTrace {
                 userID: userID,
                 completion: { _ in })
         }
+        SafeTrace.tracingStatusChangeHandler?(false)
     }
     
     public static func sendHealthCheck(wakeReason: WakeReason, completion: (() -> Void)? = nil) {

--- a/safetrace-sdk/SafeTrace.swift
+++ b/safetrace-sdk/SafeTrace.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import UIKit
 
 public enum WakeReason: String, Encodable {
@@ -63,6 +64,9 @@ public final class SafeTrace {
         let isOptedIn = environment.tracer.isTracingEnabled
         let appVersion = UIApplication.clientApplicationVersionShortDescription
         let bluetoothHardwareEnabled = environment.tracer.isBluetoothHardwareEnabled
+        let locationAuthorization = CLLocationManager.authorizationStatus()
+                let locationEnabled = locationAuthorization == .authorizedAlways
+                    || locationAuthorization == .authorizedWhenInUse
         UIDevice.current.isBatteryMonitoringEnabled = true
         let batteryLevel = Int(UIDevice.current.batteryLevel * 100)
         let isLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
@@ -76,6 +80,7 @@ public final class SafeTrace {
                 userID: userID,
                 bluetoothEnabled: bluetoothEnabled,
                 notificationsEnabled: pushEnabled,
+                locationEnabled: locationEnabled,
                 wakeReason: wakeReason,
                 isOptedIn: isOptedIn,
                 appVersion: appVersion,
@@ -175,6 +180,16 @@ public final class SafeTrace {
             sendCheck()
         }
     }
+
+    public static func syncLocation(_ location: LocationRequest, completion: (() -> Void)? = nil) {
+            guard let userID = environment.session.userID else { return }
+            let task = UIApplication.shared.beginBackgroundTask()
+
+            environment.network.syncLocation(location, userID: userID) { _ in
+                completion?()
+                UIApplication.shared.endBackgroundTask(task)
+            }
+        }
 }
 
 extension SafeTrace {

--- a/safetrace-sdk/Services/Networking/Models/LocationRequest.swift
+++ b/safetrace-sdk/Services/Networking/Models/LocationRequest.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct LocationRequest: Codable {
+    public let latitude: Double
+    public let longitude: Double
+    public let horizontalAccuracy: Double
+    public let verticalAccuracy: Double
+    public let elevation: Double
+    public let speed: Double
+    public let bearing: Double
+    public let background: Bool
+
+    public init(
+        lat: Double,
+        long: Double,
+        hAccuracy: Double,
+        vAccuracy: Double,
+        elevation: Double,
+        speed: Double,
+        bearing: Double,
+        background: Bool
+    ) {
+        self.latitude = lat
+        self.longitude = long
+        self.horizontalAccuracy = hAccuracy
+        self.verticalAccuracy = vAccuracy
+        self.elevation = elevation
+        self.speed = speed
+        self.bearing = bearing
+        self.background = background
+    }
+}

--- a/safetrace-sdk/Services/Networking/Networking.swift
+++ b/safetrace-sdk/Services/Networking/Networking.swift
@@ -18,6 +18,7 @@ protocol NetworkProtocol {
         userID: String,
         bluetoothEnabled: Bool,
         notificationsEnabled: Bool,
+        locationEnabled: Bool,
         wakeReason: WakeReason,
         isOptedIn: Bool,
         appVersion: String,
@@ -29,7 +30,8 @@ protocol NetworkProtocol {
 
     func getTraceIDs(userID: String, completion: @escaping (Result<[TraceIDRecord], Error>) -> Void)
     func uploadTraces(_ traces: ContactTraces, userID: String, completion: @escaping (Result<Void, Error>) -> Void)
-    
+
+    func syncLocation(_ location: LocationRequest, userID: String, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
 class Network: NetworkProtocol {
@@ -184,6 +186,7 @@ class Network: NetworkProtocol {
         userID: String,
         bluetoothEnabled: Bool,
         notificationsEnabled: Bool,
+        locationEnabled: Bool,
         wakeReason: WakeReason,
         isOptedIn: Bool,
         appVersion: String,
@@ -195,6 +198,7 @@ class Network: NetworkProtocol {
         struct HealthCheckPayload: Encodable {
             let bluetooth_enabled: Bool
             let notifications_enabled: Bool
+            let location_enabled: Bool
             let wake_reason: WakeReason
             let is_opted_in: Bool
             let app_version: String
@@ -212,6 +216,7 @@ class Network: NetworkProtocol {
                 body: HealthCheckPayload(
                     bluetooth_enabled: bluetoothEnabled,
                     notifications_enabled: notificationsEnabled,
+                    location_enabled: locationEnabled,
                     wake_reason: wakeReason,
                     is_opted_in: isOptedIn,
                     app_version: appVersion,
@@ -245,5 +250,19 @@ class Network: NetworkProtocol {
                 body: traces,
                 dateEncodingStrategy: .iso8601),
             completion:completion)
+    }
+
+    // MARK: - Location
+    func syncLocation(_ location: LocationRequest, userID: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        urlSession.sendRequest(
+            with: try URLRequest(
+                endpoint: "v1/users/\(userID)/location",
+                method: .post,
+                host: .sp0n,
+                token: environment.session.authToken,
+                body: location
+            ),
+            completion: completion
+        )
     }
 }

--- a/safetrace-sdk/Trace/ContactTracer.swift
+++ b/safetrace-sdk/Trace/ContactTracer.swift
@@ -1,5 +1,4 @@
 import CoreBluetooth
-import CoreLocation
 import Foundation
 import UIKit
 import UserNotifications

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -599,6 +600,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;
@@ -731,6 +733,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ctzn.safetrace-sdk";
 				PRODUCT_MODULE_NAME = SafeTrace;
 				PRODUCT_NAME = SafeTrace;

--- a/safetrace.xcodeproj/project.pbxproj
+++ b/safetrace.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E07A890252265CF000960DF /* LocationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E07A88F252265CF000960DF /* LocationRequest.swift */; };
 		DC0BBB1C24468E5B00B18911 /* SafeTrace.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC0BBB1224468E5B00B18911 /* SafeTrace.framework */; };
 		DC0BBB2324468E5B00B18911 /* safetrace_sdk.h in Headers */ = {isa = PBXBuildFile; fileRef = DC0BBB1524468E5B00B18911 /* safetrace_sdk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC0BBB2D24468EA500B18911 /* SafeTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0BBB2C24468EA500B18911 /* SafeTrace.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3E07A88F252265CF000960DF /* LocationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRequest.swift; sourceTree = "<group>"; };
 		DC0BBB1224468E5B00B18911 /* SafeTrace.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SafeTrace.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC0BBB1524468E5B00B18911 /* safetrace_sdk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = safetrace_sdk.h; sourceTree = "<group>"; };
 		DC0BBB1624468E5B00B18911 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -108,6 +110,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3E07A88E252265C3000960DF /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3E07A88F252265CF000960DF /* LocationRequest.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		DC0BBB0824468E5B00B18911 = {
 			isa = PBXGroup;
 			children = (
@@ -184,6 +194,7 @@
 		DC7AC09A24478B18000FF13D /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				3E07A88E252265C3000960DF /* Models */,
 				DC7AC09824475486000FF13D /* Networking.swift */,
 				DC7AC09B24478B3A000FF13D /* URLSession+.swift */,
 			);
@@ -376,6 +387,7 @@
 				DC7AC09F24478DF8000FF13D /* Environment.swift in Sources */,
 				DC0BBB2D24468EA500B18911 /* SafeTrace.swift in Sources */,
 				DC0BBB302446957000B18911 /* ContactTracer.swift in Sources */,
+				3E07A890252265CF000960DF /* LocationRequest.swift in Sources */,
 				DC7F32FA244A180D009B61B8 /* BluetoothCentral.swift in Sources */,
 				DC7F32F4244933DA009B61B8 /* BluetoothPeripheral.swift in Sources */,
 				DC7AC0A524479495000FF13D /* UserSession.swift in Sources */,


### PR DESCRIPTION
- If location is granted, sync location with server whenever it becomes available
- Allow background syncing of location
- Append location along with every trace
- Send new `location_enabled` field to health checks. `true` means location permissions are either granted for `.authorizedAlways` or `.authorizedWhenInUse`